### PR TITLE
Do not clean full logs folder

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,7 +50,7 @@ or change.
 * Do not include issue numbers in the PR title.
 * Follow the [JavaScript styleguide](#javascript-styleguide).
 * Follow the [Specs styleguide](#specs-styleguide).
-* All enhancements and bug fixes must be accompanied with all needed new related regression test. Not only unit tests, integration or functional tests are mandatory too.
+* All enhancements and bug fixes must be accompanied with all needed new related regression test. Not only unit tests, integration or functional tests are also required.
 * Coverage of unit tests must remain 100%.
 * Run tests often. Tests are ran automatically with Travis when you push, but you still need to run them locally before pushing.
 * Document new features, or update documentation if changes affect to it.

--- a/.narval.yml
+++ b/.narval.yml
@@ -1071,3 +1071,48 @@ suites:
             timeout: 120000
       coverage:
         enabled: false
+    - name: clean-logs-folder-local
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: simple-command
+            narval_config: clean-logs-folder-local
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+        - name: package-test-2
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+              narval_options: -- --suite=suite-2
+            wait-on: .narval/logs/integration/clean-logs-folder-local/package-test/exit-code.log
+        - name: package-test-3
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+              narval_options: -- --suite=suite-2 --local=service-2
+            wait-on: .narval/logs/integration/clean-logs-folder-local/package-test-2/exit-code.log
+        - name: package-test-4
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+              narval_options: -- --suite=suite-2 --local=test
+            wait-on: .narval/logs/integration/clean-logs-folder-local/package-test-3/exit-code.log
+      test:
+        specs:
+          - test/integration/specs/exit/exit-ok.specs.js
+          - test/integration/specs/logs/clean-logs-folder-local.specs.js
+        local:
+          wait-on:
+            resources: 
+              - .narval/logs/integration/clean-logs-folder-local/package-test-4/exit-code.log
+            timeout: 120000
+      coverage:
+        enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation fixes.
 
 ### Fixed
+- Do not clean full logs folder. Clean each suite logs folder just before executing it. Clean only the log folder of the executed service when it is ran locally as a single service.
+
 ### Removed
 
 ## [1.0.0] - 2018-05-20

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -30,8 +30,6 @@ const PathExistsSync = function (pathResolver) {
 const EnsureDir = function (pathResolver) {
   return function () {
     const absolutePath = pathResolver.apply(this, arguments)
-    console.log('ENSURING')
-    console.log(absolutePath)
     return fsExtra.ensureDir(absolutePath)
       .then(() => {
         return Promise.resolve(absolutePath)
@@ -41,8 +39,6 @@ const EnsureDir = function (pathResolver) {
 
 const Remove = function (pathResolver) {
   return function () {
-    console.log('REMOVING')
-    console.log(pathResolver.apply(this, arguments))
     return fsExtra.remove(pathResolver.apply(this, arguments))
   }
 }

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -30,6 +30,8 @@ const PathExistsSync = function (pathResolver) {
 const EnsureDir = function (pathResolver) {
   return function () {
     const absolutePath = pathResolver.apply(this, arguments)
+    console.log('ENSURING')
+    console.log(absolutePath)
     return fsExtra.ensureDir(absolutePath)
       .then(() => {
         return Promise.resolve(absolutePath)
@@ -39,6 +41,8 @@ const EnsureDir = function (pathResolver) {
 
 const Remove = function (pathResolver) {
   return function () {
+    console.log('REMOVING')
+    console.log(pathResolver.apply(this, arguments))
     return fsExtra.remove(pathResolver.apply(this, arguments))
   }
 }
@@ -107,6 +111,15 @@ const customConfig = function () {
 
 const logs = function () {
   return cwdMethods.resolve(LOGS_PATH)
+}
+
+cwdMethods.cleanLogs = function () {
+  const logsPath = Array.prototype.slice.call(arguments)
+  logsPath.unshift(LOGS_PATH)
+  return cwdMethods.remove.apply(this, logsPath)
+    .then(() => {
+      return cwdMethods.ensureDir.apply(this, logsPath)
+    })
 }
 
 const docker = function () {

--- a/lib/suite-docker.js
+++ b/lib/suite-docker.js
@@ -208,7 +208,8 @@ const Runner = function (config, logger) {
 
   const run = function () {
     states.set('docker-executed', true)
-    return runBefore()
+    return paths.cwd.cleanLogs(type, name)
+      .then(runBefore)
       .then(runServicesAndTest)
   }
 

--- a/lib/suite-local.js
+++ b/lib/suite-local.js
@@ -12,6 +12,7 @@ const waitOn = require('./wait-on')
 const libs = require('./libs')
 const utils = require('./utils')
 const states = require('./states')
+const paths = require('./paths')
 const processes = require('./processes')
 
 const Runner = function (config, logger) {
@@ -228,13 +229,19 @@ const Runner = function (config, logger) {
   const run = function () {
     const singleServiceToRun = config.singleServiceToRun()
     if (singleServiceToRun) {
-      return runSingleService(singleServiceToRun)
+      return paths.cwd.cleanLogs(type, name, singleServiceToRun.name())
+        .then(() => {
+          return runSingleService(singleServiceToRun)
+        })
     }
     if (config.runSingleTest() === true) {
       return runTest()
     }
 
-    return commands.runBefore(config, logger)
+    return paths.cwd.cleanLogs(type, name)
+      .then(() => {
+        return commands.runBefore(config, logger)
+      })
       .then(runServicesAndTest)
   }
 

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -7,7 +7,6 @@ const tracer = require('./tracer')
 const docker = require('./docker')
 const suiteLocal = require('./suite-local')
 const suiteDocker = require('./suite-docker')
-const paths = require('./paths')
 const options = require('./options')
 const config = require('./config')
 const logs = require('./logs')
@@ -68,14 +67,6 @@ const runSuitesOfType = function (suitesOfType, options, suitesByType) {
   return Promise.resolve()
 }
 
-const cleanLogs = function () {
-  const logsPath = paths.logs()
-  return paths.cwd.remove(logsPath)
-    .then(() => {
-      return paths.cwd.ensureDir(logsPath)
-    })
-}
-
 const run = function () {
   return Promise.props({
     options: options.get(),
@@ -85,12 +76,9 @@ const run = function () {
       logs.skipAllSuites()
       return Promise.resolve()
     }
-    return cleanLogs()
-      .then(() => {
-        return Promise.mapSeries(data.suitesByType, (suitesOfType) => {
-          return runSuitesOfType(suitesOfType, data.options, data.suitesByType)
-        }).finally(docker.downVolumes)
-      })
+    return Promise.mapSeries(data.suitesByType, (suitesOfType) => {
+      return runSuitesOfType(suitesOfType, data.options, data.suitesByType)
+    }).finally(docker.downVolumes)
   })
 }
 

--- a/test/integration/configs/clean-logs-folder-local.yml
+++ b/test/integration/configs/clean-logs-folder-local.yml
@@ -8,15 +8,10 @@ suites:
         - name: service-2
           local:
             command: test/commands/foo-command.sh
-            wait-on: .narval/logs/functional/suite-1/service-1/exit-code.log
-        - name: service-3
-          local:
-            command: test/commands/foo-command.sh
-            wait-on: .narval/logs/functional/suite-1/service-2/exit-code.log
       test:
         specs: test/specs/functional
         local:
-          wait-on: .narval/logs/functional/suite-1/service-3/exit-code.log
+          wait-on: .narval/logs/functional/suite-1/service-2/exit-code.log
       coverage:
         enabled: false
     - name: suite-2
@@ -27,14 +22,9 @@ suites:
         - name: service-2
           local:
             command: test/commands/foo-command.sh
-            wait-on: .narval/logs/functional/suite-2/service-1/exit-code.log
-        - name: service-3
-          local:
-            command: test/commands/foo-command.sh
-            wait-on: .narval/logs/functional/suite-2/service-2/exit-code.log
       test:
         specs: test/specs/functional
         local:
-          wait-on: .narval/logs/functional/suite-2/service-3/exit-code.log
+          wait-on: .narval/logs/functional/suite-2/service-2/exit-code.log
       coverage:
         enabled: false

--- a/test/integration/configs/clean-logs-folder-local.yml
+++ b/test/integration/configs/clean-logs-folder-local.yml
@@ -24,7 +24,5 @@ suites:
             command: test/commands/foo-command.sh
       test:
         specs: test/specs/functional
-        local:
-          wait-on: .narval/logs/functional/suite-2/service-2/exit-code.log
       coverage:
         enabled: false

--- a/test/integration/specs/logs/clean-logs-folder-local.specs.js
+++ b/test/integration/specs/logs/clean-logs-folder-local.specs.js
@@ -1,0 +1,17 @@
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+
+const checkLogs = function (suiteNumber, serviceNumber) {
+  utils.checkServiceLogs(`service-${serviceNumber}`, { err: -1 }, 'simple-command', `functional/suite-${suiteNumber}`)
+}
+
+test.describe('logs folders', () => {
+  test.describe('when single services has been executed', () => {
+    checkLogs('1', '1')
+    checkLogs('1', '2')
+    checkLogs('2', '1')
+    checkLogs('2', '2')
+  })
+})

--- a/test/integration/specs/utils.js
+++ b/test/integration/specs/utils.js
@@ -32,21 +32,22 @@ const readPackageLogs = function (packageName, suiteType, suiteName, serviceName
   })
 }
 
-const expectServiceLog = function (serviceName, logFile, minLength) {
-  const splittedFolder = process.env.logs_folder.split('/')
+const expectServiceLog = function (serviceName, logFile, minLength, packageName = 'api', baseLogsFolder) {
+  const logsFolder = baseLogsFolder || process.env.logs_folder
+  const splittedFolder = logsFolder.split('/')
   const suiteType = splittedFolder[0]
   const suite = splittedFolder[1]
 
   minLength = _.isUndefined(minLength) ? 0 : minLength
-  test.it(`should have written ${serviceName} service ${logFile} logs`, () => {
-    return readPackageLogs('api', suiteType, suite, serviceName, logFile)
+  test.it(`should have written log file "${logFile}.log" of service "${serviceName}", suite "${suite}", suite type "${suiteType}" of package "${packageName}"`, () => {
+    return readPackageLogs(packageName, suiteType, suite, serviceName, logFile)
       .then((log) => {
         return test.expect(log).to.have.lengthOf.above(minLength)
       })
   })
 }
 
-const checkServiceLogs = function (serviceName, customMinLengths) {
+const checkServiceLogs = function (serviceName, customMinLengths, packageName, baseLogsFolder) {
   let minLengths = {
     combined: 0,
     out: 0,
@@ -54,10 +55,10 @@ const checkServiceLogs = function (serviceName, customMinLengths) {
     'exit-code': 0
   }
   minLengths = Object.assign({}, minLengths, customMinLengths)
-  expectServiceLog(serviceName, 'combined-outerr', minLengths.combined)
-  expectServiceLog(serviceName, 'out', minLengths.out)
-  expectServiceLog(serviceName, 'err', minLengths.err)
-  expectServiceLog(serviceName, 'exit-code', minLengths['exit-code'])
+  expectServiceLog(serviceName, 'combined-outerr', minLengths.combined, packageName, baseLogsFolder)
+  expectServiceLog(serviceName, 'out', minLengths.out, packageName, baseLogsFolder)
+  expectServiceLog(serviceName, 'err', minLengths.err, packageName, baseLogsFolder)
+  expectServiceLog(serviceName, 'exit-code', minLengths['exit-code'], packageName, baseLogsFolder)
 }
 
 module.exports = {

--- a/test/unit/lib/paths.mocks.js
+++ b/test/unit/lib/paths.mocks.js
@@ -19,7 +19,9 @@ const Mock = function () {
   }
 
   const stubs = {
-    cwd: new PathMethods('cwd'),
+    cwd: Object.assign(new PathMethods('cwd'), {
+      cleanLogs: sandbox.stub(paths.cwd, 'cleanLogs').usingPromise().resolves()
+    }),
     package: new PathMethods('package'),
     defaultConfig: sandbox.stub(paths, 'defaultConfig'),
     customConfig: sandbox.stub(paths, 'customConfig'),

--- a/test/unit/lib/paths.specs.js
+++ b/test/unit/lib/paths.specs.js
@@ -174,6 +174,32 @@ test.describe('paths', () => {
   testRelativePathUtils('cwd', process.cwd(), 'the process current working directory')
   testRelativePathUtils('package', path.resolve(__dirname, '..', '..', '..'), 'the process current working directory')
 
+  test.describe('cwd.cleanLogs method', () => {
+    let ensureDirStub
+    let removeStub
+
+    test.beforeEach(() => {
+      ensureDirStub = test.sinon.stub(fsExtra, 'ensureDir').usingPromise().resolves()
+      removeStub = test.sinon.stub(fsExtra, 'remove').usingPromise().resolves()
+    })
+
+    test.afterEach(() => {
+      fsExtra.ensureDir.restore()
+      fsExtra.remove.restore()
+    })
+
+    test.it('should call to remove and then ensure the provided path, resolving it with under logs path', () => {
+      const fooPath = path.resolve(process.cwd(), '.narval', 'logs', 'fooPath', 'fooSubPath')
+      return paths.cwd.cleanLogs('fooPath', 'fooSubPath')
+        .then(() => {
+          return Promise.all([
+            test.expect(removeStub).to.have.been.calledWith(fooPath),
+            test.expect(ensureDirStub).to.have.been.calledWith(fooPath)
+          ])
+        })
+    })
+  })
+
   test.describe('logs method', () => {
     test.it('should return the absolute path to the the narval logs folder in the current working directory path', () => {
       const logsFolderPath = path.resolve(process.cwd(), '.narval', 'logs')

--- a/test/unit/lib/suite-docker.specs.js
+++ b/test/unit/lib/suite-docker.specs.js
@@ -81,6 +81,12 @@ test.describe('suite-docker', () => {
       })
     })
 
+    test.it('should have cleaned all suite logs folder', () => {
+      return run().then(() => {
+        return test.expect(mocksSandbox.paths.stubs.cwd.cleanLogs).to.have.been.calledWith(fooTypeName, fooSuiteName)
+      })
+    })
+
     test.it('should have executed the before command, passing to it the config and the logger', () => {
       return run().then(() => {
         return test.expect(mocksSandbox.commands.stubs.runBefore).to.have.been.calledWith(configMock, loggerMock)

--- a/test/unit/lib/suite-local.specs.js
+++ b/test/unit/lib/suite-local.specs.js
@@ -40,6 +40,7 @@ test.describe('suite-local', () => {
       'logs',
       'waiton',
       'libs',
+      'paths',
       'utils',
       'processes'
     ])

--- a/test/unit/lib/suite-local.specs.js
+++ b/test/unit/lib/suite-local.specs.js
@@ -105,6 +105,12 @@ test.describe('suite-local', () => {
           return test.expect(mocksSandbox.commands.stubs.runBefore).to.not.have.been.called()
         })
       })
+
+      test.it('should have cleaned the log folder of the service to execute', () => {
+        return run().then(() => {
+          return test.expect(mocksSandbox.paths.stubs.cwd.cleanLogs).to.have.been.calledWith(fooTypeName, fooSuiteName, fooServiceName)
+        })
+      })
     })
 
     test.describe('when running a service', () => {
@@ -321,9 +327,17 @@ test.describe('suite-local', () => {
         sandbox.stub(mochaSinonChaiRunner, 'run').resolves()
       })
 
-      test.it('should not execute the "before" command when it is ran alone', () => {
-        return run().then(() => {
-          return test.expect(mocksSandbox.commands.stubs.runBefore).to.not.have.been.called()
+      test.describe('when test is executed "alone"', () => {
+        test.it('should not execute the "before" command', () => {
+          return run().then(() => {
+            return test.expect(mocksSandbox.commands.stubs.runBefore).to.not.have.been.called()
+          })
+        })
+
+        test.it('should have not cleaned any log folder', () => {
+          return run().then(() => {
+            return test.expect(mocksSandbox.paths.stubs.cwd.cleanLogs).to.not.have.been.called()
+          })
         })
       })
 
@@ -444,6 +458,12 @@ test.describe('suite-local', () => {
         configMock.runSingleTest.returns(false)
         sandbox.stub(mochaSinonChaiRunner, 'run').resolves()
         mocksSandbox.processes.stubs.fork.resolves(0)
+      })
+
+      test.it('should have cleaned all suite logs folder', () => {
+        return run().then(() => {
+          return test.expect(mocksSandbox.paths.stubs.cwd.cleanLogs).to.have.been.calledWith(fooTypeName, fooSuiteName)
+        })
       })
 
       test.it('should print a log when test execution ends', () => {

--- a/test/unit/lib/suites.specs.js
+++ b/test/unit/lib/suites.specs.js
@@ -19,7 +19,6 @@ test.describe('suites', () => {
         'suitedocker',
         'docker',
         'tracer',
-        'paths',
         'options',
         'config',
         'logs'
@@ -61,20 +60,6 @@ test.describe('suites', () => {
           return test.expect(mocksSandbox.logs.stubs.runningSuiteType).to.have.been.calledWith({
             type: 'fooType'
           })
-        })
-    })
-
-    test.it('should clean logs folder before executing suites', () => {
-      const fooLogsPath = 'fooPath'
-      mocksSandbox.options.stubs.get.resolves(fixtures.options.suite)
-      mocksSandbox.paths.stubs.logs.returns(fooLogsPath)
-      mocksSandbox.paths.stubs.cwd.remove.resolves()
-      return suites.run()
-        .then(() => {
-          return Promise.all([
-            test.expect(mocksSandbox.paths.stubs.cwd.remove).to.have.been.calledWith(fooLogsPath),
-            test.expect(mocksSandbox.paths.stubs.cwd.ensureDir).to.have.been.calledWith(fooLogsPath)
-          ])
         })
     })
 


### PR DESCRIPTION
Do not clean full logs folder. Clean each suite logs folder just before executing it. Clean only the log folder of the executed service when it is ran locally as a single service.

closes #33 