### PR TITLE
Upgrade mocha-sinon-chai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.1.0]
+### Changed
+- Upgrade mocha-sinon-chai version
+
 ## [1.0.1] - 2018-05-28
 ### Added
 - Lighter npm distribution. Ignore not needed resources.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narval",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Multi test suites runner for Node.js packages. Docker based",
   "main": "index.js",
   "keywords": [
@@ -13,6 +13,7 @@
     "testing",
     "test suites",
     "unit test",
+    "acceptance test",
     "integration test",
     "end to end test",
     "standardjs",
@@ -40,7 +41,7 @@
     "handlebars": "4.0.11",
     "js-yaml": "3.11.0",
     "lodash": "4.17.10",
-    "mocha-sinon-chai": "2.3.0",
+    "mocha-sinon-chai": "2.4.0",
     "standard": "11.0.1",
     "tracer": "0.8.15",
     "tree-kill": "1.2.0",
@@ -51,13 +52,9 @@
     "coveralls": "3.0.1",
     "mockery": "2.1.0"
   },
-  "engines": {
-    "node": "8.11.1",
-    "npm": "5.6.0"
-  },
   "author": {
     "name": "Javier Brea",
-    "url": "http://javierbrea.com"
+    "url": "https://javierbrea.com"
   },
   "license": "MIT",
   "repository": "https://github.com/javierbrea/narval"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=narval
-sonar.projectVersion=1.0.1
+sonar.projectVersion=1.1.0
 
 sonar.sources=.
 sonar.exclusions=node_modules/**,test/integration/packages/**

--- a/test/integration/packages/api/test/unit/server.specs.js
+++ b/test/integration/packages/api/test/unit/server.specs.js
@@ -7,7 +7,7 @@ test.describe('server', function () {
   let sandbox
 
   test.before(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     sandbox.stub(serverLib, 'start').usingPromise().resolves()
   })
 

--- a/test/unit/lib/childProcess.mocks.js
+++ b/test/unit/lib/childProcess.mocks.js
@@ -5,7 +5,7 @@ const test = require('../../../index')
 const utils = require('../utils')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
   let forkStub
   let forkOnFake
   let forkSendFake

--- a/test/unit/lib/commands.mocks.js
+++ b/test/unit/lib/commands.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const commands = require('../../../lib/commands')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   let stubs = {
     run: sandbox.stub(commands, 'run').usingPromise().resolves(),

--- a/test/unit/lib/commands.specs.js
+++ b/test/unit/lib/commands.specs.js
@@ -16,7 +16,7 @@ test.describe('commands', () => {
   let mocksSandbox
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'options',
       'processes',

--- a/test/unit/lib/config.mocks.js
+++ b/test/unit/lib/config.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const config = require('../../../lib/config')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const serviceResolverStubs = {
     waitOn: sandbox.stub(),

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -16,7 +16,7 @@ test.describe('config', () => {
   let mocksSandbox
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'paths',
       'logs',

--- a/test/unit/lib/docker.mocks.js
+++ b/test/unit/lib/docker.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const docker = require('../../../lib/docker')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   let stubs = {
     createFiles: sandbox.stub(docker, 'createFiles').usingPromise().resolves(),

--- a/test/unit/lib/docker.specs.js
+++ b/test/unit/lib/docker.specs.js
@@ -14,7 +14,7 @@ test.describe('docker', () => {
   let mocksSandbox
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'paths',
       'config',

--- a/test/unit/lib/fs.mocks.js
+++ b/test/unit/lib/fs.mocks.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const test = require('../../../index')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
   let readFileFake
   let writeFileFake
   let readFileStub

--- a/test/unit/lib/libs.mocks.js
+++ b/test/unit/lib/libs.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const libs = require('../../../lib/libs')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
   let waitFake
   let waitStub
   let treeKillStub

--- a/test/unit/lib/logs.mocks.js
+++ b/test/unit/lib/logs.mocks.js
@@ -5,7 +5,7 @@ const test = require('../../../index')
 const logs = require('../../../lib/logs')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const suiteLoggerStubs = {
     skip: sandbox.stub(),

--- a/test/unit/lib/logs.specs.js
+++ b/test/unit/lib/logs.specs.js
@@ -9,7 +9,7 @@ test.describe('logs', () => {
   let mocksSandbox
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'tracer',
       'config'

--- a/test/unit/lib/options.mocks.js
+++ b/test/unit/lib/options.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const options = require('../../../lib/options')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const stubs = {
     get: sandbox.stub(options, 'get').usingPromise().resolves({})

--- a/test/unit/lib/options.specs.js
+++ b/test/unit/lib/options.specs.js
@@ -39,7 +39,7 @@ test.describe('options', () => {
 
     test.beforeEach(() => {
       commanderMock = new CommanderMock()
-      sandbox = test.sinon.sandbox.create()
+      sandbox = test.sinon.createSandbox()
       sandbox.stub(commander, 'option').callsFake(commanderMock.option)
       sandbox.stub(states, 'get').returns(undefined)
       sandbox.stub(states, 'set')

--- a/test/unit/lib/paths.mocks.js
+++ b/test/unit/lib/paths.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const paths = require('../../../lib/paths')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const PathMethods = function (base) {
     return {

--- a/test/unit/lib/processes.mocks.js
+++ b/test/unit/lib/processes.mocks.js
@@ -8,7 +8,7 @@ const ChildProcessMocks = require('./childProcess.mocks')
 const utils = require('../utils')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
   const handlerOnFake = new utils.CallBackRunnerFake({
     runOnRegister: false
   })

--- a/test/unit/lib/processes.specs.js
+++ b/test/unit/lib/processes.specs.js
@@ -13,7 +13,7 @@ test.describe('processes', () => {
   let childProcessMock
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     sandbox.spy(console, 'log')
     mocksSandbox = new mocks.Sandbox([
       'paths',

--- a/test/unit/lib/runner.specs.js
+++ b/test/unit/lib/runner.specs.js
@@ -21,7 +21,7 @@ test.describe('runner', () => {
       warnOnUnregistered: false
     })
 
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
 
     tracer = require('../../../lib/tracer')
     states = require('../../../lib/states')

--- a/test/unit/lib/service-coverage-runner.specs.js
+++ b/test/unit/lib/service-coverage-runner.specs.js
@@ -6,7 +6,7 @@ const mocks = require('../mocks')
 test.describe('service coverage runner', () => {
   const fooServicePath = 'fooServicePath'
   const originalServicePath = process.env.servicePath
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
   let requireError
   let tracerMock
   let processMock

--- a/test/unit/lib/standard.specs.js
+++ b/test/unit/lib/standard.specs.js
@@ -14,7 +14,7 @@ test.describe('standard', () => {
     let mocksSandbox
 
     test.beforeEach(() => {
-      sandbox = test.sinon.sandbox.create()
+      sandbox = test.sinon.createSandbox()
       mocksSandbox = new mocks.Sandbox([
         'logs',
         'paths',

--- a/test/unit/lib/suite-docker.specs.js
+++ b/test/unit/lib/suite-docker.specs.js
@@ -14,7 +14,7 @@ test.describe('suite-docker', () => {
   let mocksSandbox
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'docker',
       'paths',

--- a/test/unit/lib/suite-local.specs.js
+++ b/test/unit/lib/suite-local.specs.js
@@ -33,7 +33,7 @@ test.describe('suite-local', () => {
   let stdinOnFake
 
   test.beforeEach(() => {
-    sandbox = test.sinon.sandbox.create()
+    sandbox = test.sinon.createSandbox()
     mocksSandbox = new mocks.Sandbox([
       'commands',
       'config',

--- a/test/unit/lib/suite-type.mocks.js
+++ b/test/unit/lib/suite-type.mocks.js
@@ -7,7 +7,7 @@ const suiteTypes = {
 }
 
 const Mock = function (mockToCreate) {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const runnerStubs = {
     run: sandbox.stub().usingPromise().resolves()

--- a/test/unit/lib/suites.specs.js
+++ b/test/unit/lib/suites.specs.js
@@ -10,7 +10,7 @@ const suites = require('../../../lib/suites')
 
 test.describe('suites', () => {
   test.describe('run method', () => {
-    const sandbox = test.sinon.sandbox.create()
+    const sandbox = test.sinon.createSandbox()
     let mocksSandbox
 
     test.beforeEach(() => {

--- a/test/unit/lib/tracer.mocks.js
+++ b/test/unit/lib/tracer.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const tracer = require('../../../lib/tracer')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const stubs = {
     log: sandbox.stub(tracer, 'log'),

--- a/test/unit/lib/utils.mocks.js
+++ b/test/unit/lib/utils.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const utils = require('../../../lib/utils')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const stubs = {
     ObjectToArguments: sandbox.stub(utils, 'ObjectToArguments'),

--- a/test/unit/lib/wait-on.mocks.js
+++ b/test/unit/lib/wait-on.mocks.js
@@ -4,7 +4,7 @@ const test = require('../../../index')
 const waitOn = require('../../../lib/wait-on')
 
 const Mock = function () {
-  const sandbox = test.sinon.sandbox.create()
+  const sandbox = test.sinon.createSandbox()
 
   const stubs = {
     wait: sandbox.stub(waitOn, 'wait').usingPromise().resolves(),


### PR DESCRIPTION
Upgrade mocha-sinon-chai dependency. In tests, use new `sinon.createSandbox` method instead of deprecated `sinon.sandbox.create`

closes #42 
