### PR TITLE
Wait on service exit

### DIFF
--- a/.narval.yml
+++ b/.narval.yml
@@ -1092,6 +1092,29 @@ suites:
           wait-on: exit:package-test
       coverage:
         enabled: false
+    - name: docker-services-waiting-custom-close
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: simple-command
+            narval_config: docker-services-waiting-custom-close
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+      test:
+        specs:
+          - test/integration/specs/exit/exit-ok.specs.js
+          - test/integration/specs/logs/docker-services-waiting-close.specs.js
+        local:
+          wait-on:
+            resources: exit:package-test
+            timeout: 120000
+      coverage:
+        enabled: false
     - name: clean-logs-folder-local
       before:
         local:

--- a/.narval.yml
+++ b/.narval.yml
@@ -1071,6 +1071,27 @@ suites:
             timeout: 120000
       coverage:
         enabled: false
+    - name: local-services-waiting-custom-close
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: simple-command
+            narval_config: local-services-waiting-custom-close
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: simple-command
+      test:
+        specs:
+          - test/integration/specs/exit/exit-ok.specs.js
+          - test/integration/specs/logs/local-services-waiting-close.specs.js
+        local:
+          wait-on: exit:package-test
+      coverage:
+        enabled: false
     - name: clean-logs-folder-local
       before:
         local:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ## [1.1.0]
+### Added
+- Add new custom "wait-on" value to wait for a service to be finished: wait-on: exit:service-name
+
 ### Changed
 - Upgrade mocha-sinon-chai version
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ![Narval Logo][narval-logo-image]
 
-Multi test suites runner for Node.js packages. Docker based.
+Multi test suites runner for Node.js packages. Powered by [Docker][docker-url].
 
 [![Build status][travisci-image]][travisci-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![js-standard-style][standard-image]][standard-url]
 
-[![Node version][node-version-image]][node-version-url] [![NPM version][npm-image]][npm-url] [![NPM dependencies][npm-dependencies-image]][npm-dependencies-url] [![Last commit][last-commit-image]][last-commit-url] [![Last release][release-image]][release-url] 
+[![NPM dependencies][npm-dependencies-image]][npm-dependencies-url] [![Last commit][last-commit-image]][last-commit-url] [![Last release][release-image]][release-url] 
 
 [![NPM downloads][npm-downloads-image]][npm-downloads-url] [![License][license-image]][license-url]
 
@@ -815,10 +815,7 @@ Contributions are welcome! Read the [contributing guide lines][narval-contributi
 [last-commit-url]: https://github.com/javierbrea/narval/commits
 [license-image]: https://img.shields.io/npm/l/narval.svg
 [license-url]: https://github.com/javierbrea/narval/blob/master/LICENSE
-[node-version-image]: https://img.shields.io/node/v/narval.svg
-[node-version-url]: https://github.com/javierbrea/narval/blob/master/package.json
-[npm-image]: https://img.shields.io/npm/v/narval.svg
-[npm-url]: https://www.npmjs.com/package/narval
+
 [npm-downloads-image]: https://img.shields.io/npm/dm/narval.svg
 [npm-downloads-url]: https://www.npmjs.com/package/narval
 [npm-dependencies-image]: https://img.shields.io/david/javierbrea/narval.svg

--- a/lib/config.js
+++ b/lib/config.js
@@ -260,7 +260,7 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
   const getWaitOn = function (obj) {
     let waitOnConfig = obj[_modeKey] && obj[_modeKey]['wait-on']
     if (!waitOnConfig) {
-      return null
+      return undefined
     }
     if (_.isString(waitOnConfig)) {
       waitOnConfig = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -268,12 +268,6 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
       }
     }
 
-    if (_.isString(waitOnConfig)) {
-      waitOnConfig = {
-        resources: waitOnConfig.split(' ')
-      }
-    }
-
     if (_.isString(waitOnConfig.resources)) {
       waitOnConfig.resources = waitOnConfig.resources.split(' ')
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const path = require('path')
+
 const Promise = require('bluebird')
 const yaml = require('js-yaml')
 const fs = require('fs')
@@ -247,8 +249,32 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
     return suiteData.before && suiteData.before[_modeKey] && suiteData.before[_modeKey].command
   }
 
+  const parseCustomWaitOn = function (waitOnResource) {
+    const exitKey = 'exit:'
+    if (waitOnResource.indexOf(exitKey) === 0) {
+      return path.join('.narval', 'logs', suiteTypeName, name, waitOnResource.replace(exitKey, ''), 'exit-code.log')
+    }
+    return waitOnResource
+  }
+
+  const getWaitOn = function (obj) {
+    let waitOnConfig = obj[_modeKey] && obj[_modeKey]['wait-on']
+    if (!waitOnConfig) {
+      return null
+    }
+    if (_.isString(waitOnConfig)) {
+      waitOnConfig = {
+        resources: waitOnConfig.split(' ')
+      }
+    }
+
+    waitOnConfig.resources = _.map(waitOnConfig.resources, parseCustomWaitOn)
+
+    return waitOnConfig
+  }
+
   const testWaitOn = function () {
-    return suiteData.test[_modeKey] && suiteData.test[_modeKey]['wait-on']
+    return getWaitOn(suiteData.test)
   }
 
   const testIsCoveraged = function () {
@@ -296,7 +322,7 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
     const _name = serviceData.name
 
     const waitOn = function () {
-      return serviceData[_modeKey] && serviceData[_modeKey]['wait-on']
+      return getWaitOn(serviceData)
     }
 
     const command = function () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -268,6 +268,16 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
       }
     }
 
+    if (_.isString(waitOnConfig)) {
+      waitOnConfig = {
+        resources: waitOnConfig.split(' ')
+      }
+    }
+
+    if (_.isString(waitOnConfig.resources)) {
+      waitOnConfig.resources = waitOnConfig.resources.split(' ')
+    }
+
     waitOnConfig.resources = _.map(waitOnConfig.resources, parseCustomWaitOn)
 
     return waitOnConfig

--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -7,9 +7,6 @@ const libs = require('./libs')
 
 const configToArguments = function (config = {}) {
   let options = []
-  if (_.isString(config)) {
-    return config
-  }
 
   options.push(config.timeout ? `--timeout=${config.timeout}` : null)
   options.push(config.delay ? `--delay=${config.delay}` : null)
@@ -26,32 +23,28 @@ const wait = function (config) {
     timeout: 60000
   }
   let customConfigLog = ''
-  let waitOnOptions = {}
   if (!config) {
     return Promise.resolve()
   }
-  if (_.isString(config)) {
-    waitOnOptions.resources = config.split(' ')
-  } else {
-    customConfigLog = logs.waitConfig({
-      config: JSON.stringify(config)
-    }, false)
-    waitOnOptions = config
-  }
+
+  customConfigLog = logs.waitConfig({
+    config: JSON.stringify(config)
+  }, false)
+
   return new Promise((resolve, reject) => {
     logs.waitingOn({
-      resources: waitOnOptions.resources,
+      resources: config.resources,
       customConfig: customConfigLog
     })
-    libs.waitOn(Object.assign({}, waitOnDefaultOptions, waitOnOptions), (error) => {
+    libs.waitOn(Object.assign({}, waitOnDefaultOptions, config), (error) => {
       if (error) {
         logs.waitTimeOut({
-          resources: waitOnOptions.resources
+          resources: config.resources
         })
         reject(error)
       } else {
         logs.waitFinish({
-          resources: waitOnOptions.resources
+          resources: config.resources
         })
         resolve()
       }

--- a/test/integration/commands/prepare-package.sh
+++ b/test/integration/commands/prepare-package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BASE_PATH="test/integration/packages"
-NARVAL_FOO_NODE_MODULES="$BASE_PATH/api/_node_modules"
+NARVAL_FOO_NODE_MODULES="$BASE_PATH/${package_to_launch}/_node_modules"
 NARVAL_LIB_DEST="${NARVAL_FOO_NODE_MODULES}/narval"
 NARVAL_FILE="$BASE_PATH/${package_to_launch}/.narval.yml"
 COVERAGE_FOLDER="$BASE_PATH/${package_to_launch}/.coverage"
@@ -22,7 +22,7 @@ if [ -f $NARVAL_FILE ]; then
   rm $NARVAL_FILE
 fi
 
-if [ ${package_to_launch} == "api" ]; then
+if [ ${package_to_launch} == "api" ] || [ ${package_to_launch} == "simple-command" ]; then
   # Copy Narval itself to the foo package. Link it in the package.json using "file:".
   # The installation folder is added to the Docker image, so they will use it from file system as well.
   rm -rf ${NARVAL_FOO_NODE_MODULES}

--- a/test/integration/configs/docker-services-waiting-custom-close.yml
+++ b/test/integration/configs/docker-services-waiting-custom-close.yml
@@ -7,19 +7,19 @@ docker-images:
     install: test/commands/install.sh
 docker-containers:
   - name: service-1-container
-    build: node-image
+    build: node-simple-command-image
     bind:
       - test
   - name: service-2-container
-    build: node-image
+    build: node-simple-command-image
     bind:
       - test
   - name: service-3-container
-    build: node-image
+    build: node-simple-command-image
     bind:
       - test
   - name: test-container
-    build: node-image
+    build: node-simple-command-image
     bind:
       - test
 suites:

--- a/test/integration/configs/docker-services-waiting-custom-close.yml
+++ b/test/integration/configs/docker-services-waiting-custom-close.yml
@@ -1,0 +1,72 @@
+docker-images:
+  - name: node-simple-command-image
+    from: node:8.11.1
+    add:
+      - _node_modules
+      - package.json
+    install: test/commands/install.sh
+docker-containers:
+  - name: service-1-container
+    build: node-image
+    bind:
+      - test
+  - name: service-2-container
+    build: node-image
+    bind:
+      - test
+  - name: service-3-container
+    build: node-image
+    bind:
+      - test
+  - name: test-container
+    build: node-image
+    bind:
+      - test
+suites:
+  functional:
+    - name: suite-1
+      services:
+        - name: service-1
+          docker:
+            container: service-1-container
+            command: test/commands/foo-command.sh
+        - name: service-2
+          docker:
+            container: service-2-container
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-1
+        - name: service-3
+          docker:
+            container: service-3-container
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-2
+      test:
+        specs: test/specs/functional
+        docker:
+          container: test-container
+          wait-on: exit:service-3
+      coverage:
+        enabled: false
+    - name: suite-2
+      services:
+        - name: service-1
+          docker:
+            container: service-1-container
+            command: test/commands/foo-command.sh
+        - name: service-2
+          docker:
+            container: service-2-container
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-1
+        - name: service-3
+          docker:
+            container: service-3-container
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-2
+      test:
+        specs: test/specs/functional
+        docker:
+          container: test-container
+          wait-on: exit:service-3
+      coverage:
+        enabled: false

--- a/test/integration/configs/local-services-waiting-custom-close.yml
+++ b/test/integration/configs/local-services-waiting-custom-close.yml
@@ -1,0 +1,40 @@
+suites:
+  functional:
+    - name: suite-1
+      services:
+        - name: service-1
+          local:
+            command: test/commands/foo-command.sh
+        - name: service-2
+          local:
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-1
+        - name: service-3
+          local:
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-2
+      test:
+        specs: test/specs/functional
+        local:
+          wait-on: exit:service-3
+      coverage:
+        enabled: false
+    - name: suite-2
+      services:
+        - name: service-1
+          local:
+            command: test/commands/foo-command.sh
+        - name: service-2
+          local:
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-1
+        - name: service-3
+          local:
+            command: test/commands/foo-command.sh
+            wait-on: exit:service-2
+      test:
+        specs: test/specs/functional
+        local:
+          wait-on: exit:service-3
+      coverage:
+        enabled: false

--- a/test/integration/packages/simple-command/.gitignore
+++ b/test/integration/packages/simple-command/.gitignore
@@ -1,2 +1,4 @@
+_node_modules
+.shared
 .narval.yml
 .narval

--- a/test/integration/packages/simple-command/package.json
+++ b/test/integration/packages/simple-command/package.json
@@ -5,7 +5,7 @@
     "test": "narval"
   },
   "devDependencies": {
-    "narval": "file:../../../../"
+    "narval": "file:_node_modules/narval"
   },
   "repository": "foo-repository",
   "license": "MIT"

--- a/test/integration/packages/simple-command/test/commands/install.sh
+++ b/test/integration/packages/simple-command/test/commands/install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+npm i

--- a/test/integration/specs/logs/docker-services-waiting-close.specs.js
+++ b/test/integration/specs/logs/docker-services-waiting-close.specs.js
@@ -1,0 +1,33 @@
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expectServiceSuite = function (suiteNumber, serviceNumber) {
+    test.expect(outerrLog).to.include(`Foo command of service service-${serviceNumber} of suite suite-${suiteNumber} has been executed`)
+    test.expect(outerrLog).to.include(`docker_service-${serviceNumber}-container_1 exited with code 0`)
+  }
+
+  test.it('should have executed and log exit of all services in suite-1', () => {
+    expectServiceSuite('1', '1')
+    expectServiceSuite('1', '2')
+    expectServiceSuite('1', '3')
+  })
+
+  test.it('should have executed and log exit of all services in suite-2', () => {
+    expectServiceSuite('2', '1')
+    expectServiceSuite('2', '2')
+    expectServiceSuite('2', '3')
+  })
+})

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -447,6 +447,21 @@ test.describe('config', () => {
         })
       })
 
+      test.it('should convert resources to an array when an string is provided', () => {
+        baseData.test.docker = {
+          'wait-on': {
+            resources: 'fooResource:1 fooResource2/foo'
+          }
+        }
+        initResolver()
+        test.expect(suiteResolver.testWaitOn()).to.deep.equal({
+          resources: [
+            'fooResource:1',
+            'fooResource2/foo'
+          ]
+        })
+      })
+
       test.it('should convert custom wait-on expression for waiting services to be finished to a path to the correspondant exit-code log file', () => {
         baseData.test.docker = {
           'wait-on': 'exit:fooService'

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -428,10 +428,10 @@ test.describe('config', () => {
         foo: 'foo'
       }
 
-      test.it('should return null if there is no waitOn configuration', () => {
+      test.it('should return undefined if there is no waitOn configuration', () => {
         baseData.test.docker = {}
         initResolver()
-        test.expect(suiteResolver.testWaitOn()).to.equal(null)
+        test.expect(suiteResolver.testWaitOn()).to.be.undefined()
       })
 
       test.it('should return resources when an string is provided as configuration, splitting them by blank spaces', () => {
@@ -620,10 +620,10 @@ test.describe('config', () => {
             })
           })
 
-          test.it('should return null if there is no waitOn configuration', () => {
+          test.it('should return undefined if there is no waitOn configuration', () => {
             baseData.services[0].docker = {}
             initResolver()
-            test.expect(service.waitOn()).to.equal(null)
+            test.expect(service.waitOn()).to.be.undefined()
           })
 
           test.it('should return resources when an string is provided as configuration, splitting them by blank spaces', () => {

--- a/test/unit/lib/wait-on.specs.js
+++ b/test/unit/lib/wait-on.specs.js
@@ -38,16 +38,6 @@ test.describe('wait-on', () => {
       })
     })
 
-    test.it('should consider received config as "resources" if it is an string', () => {
-      return waitOn.wait('foo-resource testing').then(() => {
-        return test.expect(mocksSandbox.libs.stubs.waitOn).to.have.been.calledWith({
-          interval: 100,
-          timeout: 60000,
-          resources: ['foo-resource', 'testing']
-        })
-      })
-    })
-
     test.it('should print a log before launching waitOn, with information about the configuration', () => {
       return waitOn.wait({
         resources: ['foo resource', 'foo'],
@@ -99,11 +89,6 @@ test.describe('wait-on', () => {
   })
 
   test.describe('configToArguments method', () => {
-    test.it('should return the same value if an string is provided', () => {
-      const fooConfigValue = 'foo config value'
-      test.expect(waitOn.configToArguments(fooConfigValue)).to.equal(fooConfigValue)
-    })
-
     test.it('should return an string containing commands arguments for wait-on library based on the provided configuration object', () => {
       test.expect(waitOn.configToArguments({
         timeout: 3000,


### PR DESCRIPTION
Add new custom "wait-on" value to wait for a service to be finished.
Now  it is not necessary any more to define a "wait-on" property pointing to the exit-code.log file of the target service which you are waiting for. This changes improves the reusability of the tests suites, and avoid to make reference to a narval generated file (which is dependent of the implementation) in the suites configuration.

closes #24 
