### PR TITLE
Increase coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 ### Removed
+### BREAKING CHANGES
+- Unit tests coverage can decrease because new version of Istanbul is more strict with branches. Now it checks default function parameters.
 
 ## [1.2.0] - 2018-06-18
 ### Changed

--- a/lib/config.js
+++ b/lib/config.js
@@ -157,14 +157,14 @@ const dockerContainers = new GetConfigMainObject('dockerContainers')
 const mochaArguments = new utils.ObjectToArguments(MOCHA_DEFAULT)
 const istanbulArguments = new utils.ObjectToArguments(ISTANBUL_DEFAULT, '=', ['x', 'i'])
 
-const addEnvironmentContainerVars = function (object, containerVarName, values = {}) {
+const addEnvironmentContainerVars = function (object, containerVarName, values) {
   values = Object.assign({}, BASE_DOCKER_ENV_VARS, values)
   _.each(values, (value, key) => {
     object[`${containerVarName}_${key}`] = value
   })
 }
 
-const addCustomDockerEnvVars = function (confObj = {}, vars = []) {
+const addCustomDockerEnvVars = function (confObj = {}, vars) {
   if (confObj.docker) {
     _.each(confObj.docker.env, (value, key) => {
       vars.push(key)

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -223,6 +223,21 @@ test.describe('config', () => {
           ])
         })
     })
+
+    test.it('should not throw an error if no test, before or services are defined', () => {
+      returnsConfig({
+        suites: {
+          fooType: [{
+            name: 'fooDockerSuite'
+          }]
+        }
+      })
+      return config.allDockerCustomEnvVars()
+        .then((allDockerCustomEnvVars) => {
+          return test.expect(allDockerCustomEnvVars).to.deep.equal([
+          ])
+        })
+    })
   })
 
   test.describe('allComposeEnvVars method', () => {

--- a/test/unit/lib/wait-on.specs.js
+++ b/test/unit/lib/wait-on.specs.js
@@ -114,5 +114,9 @@ test.describe('wait-on', () => {
         resources: 'fooValue'
       })).to.equal('fooValue')
     })
+
+    test.it('should return an empty string if no config is provided', () => {
+      test.expect(waitOn.configToArguments()).to.equal('')
+    })
   })
 })


### PR DESCRIPTION
- Increase unit tests coverage because new version of Istanbul is more strict with branches. Now it checks default function parameters.
