### PR TITLE
Release 2.1.0

### DIFF
--- a/.narval.yml
+++ b/.narval.yml
@@ -1211,6 +1211,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-log
+      describe: Should print all logs when option logLevel is "log"
       before:
         local:
           command: test/integration/commands/prepare-package.sh
@@ -1239,6 +1240,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-trace
+      describe: Should print only logs with log level "trace" or upper when option logLevel is "trace"
       before:
         local:
           command: test/integration/commands/prepare-package.sh
@@ -1267,6 +1269,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-debug
+      describe: Should print only logs with log level "debug" or upper when option logLevel is "debug"
       before:
         local:
           command: test/integration/commands/prepare-package.sh
@@ -1295,6 +1298,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-info
+      describe: Should print only logs with log level "info" or upper when option logLevel is "info"
       before:
         local:
           command: test/integration/commands/prepare-package.sh
@@ -1322,6 +1326,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-warn
+      describe: Should print only logs with log levels "warn" or "error" when option logLevel is "warn"
       before:
         local:
           command: test/integration/commands/prepare-package.sh
@@ -1350,6 +1355,7 @@ suites:
       coverage:
         enabled: false
     - name: log-level-error
+      describe: Should print only logs with log level "error" when option logLevel is "error"
       before:
         local:
           command: test/integration/commands/prepare-package.sh

--- a/.narval.yml
+++ b/.narval.yml
@@ -1208,3 +1208,171 @@ suites:
             coverage_dir: .coverage/included
       coverage:
         enabled: false
+    - name: log-level-log
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+              narval_options: -- --logLevel=log
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-log.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+    - name: log-level-trace
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+              narval_options: -- --logLevel=trace
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-trace.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+    - name: log-level-debug
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+              narval_options: -- --logLevel=debug
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-debug.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+    - name: log-level-info
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-info.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+    - name: log-level-warn
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+              narval_options: -- --logLevel=warn
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-warn.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+    - name: log-level-error
+      before:
+        local:
+          command: test/integration/commands/prepare-package.sh
+          env:
+            package_to_launch: api
+            narval_config: api
+      services:
+        - name: package-test
+          local:
+            command: test/integration/commands/launch-test.sh
+            env:
+              package_to_launch: api
+              narval_options: -- --logLevel=error
+      test:
+        specs:
+          - test/integration/specs/log-levels/api-error.specs.js
+          - test/integration/specs/exit/exit-ok.specs.js
+        local:
+          wait-on:
+            resources: 
+              - exit:package-test
+            timeout: 1200000
+          env:
+            package_to_launch: api
+            coverage_dir: .coverage/unit
+      coverage:
+        enabled: false
+

--- a/.narval.yml
+++ b/.narval.yml
@@ -259,6 +259,7 @@ suites:
           - test/integration/specs/api-docker
           - test/integration/specs/exit/exit-ok.specs.js
           - test/integration/specs/environment/defaults.specs.js
+          - test/integration/specs/descriptions/api.specs.js
         local:
           wait-on:
             resources: 
@@ -297,6 +298,7 @@ suites:
           - test/integration/specs/api-local
           - test/integration/specs/exit/exit-ok.specs.js
           - test/integration/specs/environment/defaults.specs.js
+          - test/integration/specs/descriptions/api-no-mongo.specs.js
         local:
           wait-on:
             resources: 

--- a/.narval.yml
+++ b/.narval.yml
@@ -19,6 +19,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: sum
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -73,7 +74,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: standard-ko
-              narval_options: -- --standard
+              narval_options: -- --standard --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -98,7 +99,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: standard-ko
-              narval_options: -- --fix
+              narval_options: -- --fix --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -124,6 +125,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: standard-ko
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -148,6 +150,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: sum
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -178,6 +181,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: sum
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -208,6 +212,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: sum
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -237,7 +242,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --build
+              narval_options: -- --build --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -277,7 +282,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -315,7 +320,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --suite=books-api --local --shell=/foo/path/to/shell
+              narval_options: -- --suite=books-api --local --shell=/foo/path/to/shell --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -344,6 +349,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js
@@ -383,7 +389,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --suite=books-api
+              narval_options: -- --suite=books-api --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -421,7 +427,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --suite=books-api
+              narval_options: -- --suite=books-api --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -459,7 +465,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --suite=books-api
+              narval_options: -- --suite=books-api --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -494,7 +500,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --suite=books-api
+              narval_options: -- --suite=books-api --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -529,7 +535,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --type=integration
+              narval_options: -- --type=integration --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -563,7 +569,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --type=integration --local
+              narval_options: -- --type=integration --local --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-not-run.specs.js
@@ -595,6 +601,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/docker/not-build.specs.js
@@ -626,7 +633,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/docker/not-run.specs.js
@@ -656,7 +663,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/docker/not-run.specs.js
@@ -686,6 +693,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -719,7 +727,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -753,6 +761,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -784,7 +793,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -816,6 +825,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -848,7 +858,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -882,7 +892,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local
+              narval_options: -- --local --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -915,7 +925,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local=api-server
+              narval_options: -- --local=api-server --logLevel=log
       test:
         specs:
           - test/integration/packages/api/test/end-to-end/books
@@ -942,7 +952,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local=test
+              narval_options: -- --local=test --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -967,13 +977,13 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local=api-server
+              narval_options: -- --local=api-server --logLevel=log
         - name: package-test
           local:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
-              narval_options: -- --local=test
+              narval_options: -- --local=test --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -998,6 +1008,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -1030,6 +1041,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: api
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ko.specs.js
@@ -1060,6 +1072,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -1084,6 +1097,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -1105,6 +1119,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/exit/exit-ok.specs.js
@@ -1128,26 +1143,27 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
+              narval_options: -- --logLevel=log
         - name: package-test-2
           local:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
-              narval_options: -- --suite=suite-2
+              narval_options: -- --suite=suite-2 --logLevel=log
             wait-on: .narval/logs/integration/clean-logs-folder-local/package-test/exit-code.log
         - name: package-test-3
           local:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
-              narval_options: -- --suite=suite-2 --local=service-2
+              narval_options: -- --suite=suite-2 --local=service-2 --logLevel=log
             wait-on: .narval/logs/integration/clean-logs-folder-local/package-test-2/exit-code.log
         - name: package-test-4
           local:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: simple-command
-              narval_options: -- --suite=suite-2 --local=test
+              narval_options: -- --suite=suite-2 --local=test --logLevel=log
             wait-on: .narval/logs/integration/clean-logs-folder-local/package-test-3/exit-code.log
       test:
         specs:
@@ -1174,6 +1190,7 @@ suites:
             command: test/integration/commands/launch-test.sh
             env:
               package_to_launch: sum
+              narval_options: -- --logLevel=log
       test:
         specs:
           - test/integration/specs/standard/standard-run.specs.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- Add logLevel option
 ### Changed
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
-- Add logLevel option
-- Add describe property to suites. Log the description when suite starts.
 ### Changed
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+
+## [2.1.0] - 2018-08-17
+### Added
+- Add logLevel option.
+- Add describe property to suites. Log the description when suite starts.
 
 ## [2.0.0] - 2018-08-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 - Add logLevel option
+- Add describe property to suites. Log the description when suite starts.
 ### Changed
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ docker-containers:
 `<Object>`. Object containing the test suite configuration.
 
 * `name` `<String>`. Reference for the test suite.
+* `describe` `<String>`. Description of the suite. Printed in logs when suite starts.
 * `before` `<Object>`. [before object](#before) containing configuration for commands that will be executed before running the test suite. Useful to clean or prepare your environment.
 * `services` `<Array>` of [service objects](#service). Defines services to be started before running the tests.
 * `test` `<Object>`. [test object](#test) containing configuration of the test to be runned by this suite.
@@ -697,6 +698,7 @@ docker-containers:
 suites:
   unit: 
     - name: unit
+      describe: Unitary tests
       test:
         specs: test/unit
       coverage:
@@ -704,6 +706,7 @@ suites:
           dir: .coverage/unit
   end-to-end:
     - name: books-api
+      describe: Books api should work and save data to mongodb.
       before:
         docker:
           down-volumes: true
@@ -737,6 +740,7 @@ suites:
         from: api-server
   integration:
     - name: logs
+      describe: Books api logs should work and print logs when an api request is received.
       services:
         - name: mongodb
           docker:
@@ -778,6 +782,7 @@ suites:
       coverage:
         enabled: false
     - name: commands
+      describe: Books api command should work and write all books to a file in json format.
       services:
         - name: mongodb
           docker:
@@ -813,6 +818,7 @@ suites:
             api_port: 4000
       coverage:
         enabled: false
+
 ```
 
 > NOTE: There are more files with many other configurations that may be useful as examples at the [integration tests folder of this repository][integration-tests-config-url]. All these Narval configuration files are used for testing Narval itself, and most of them are runned over the ["foo api package" in the integration tests folder][integration-tests-foo-package-url].

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Narval Logo][narval-logo-image]
 
-Multi test suites runner for Node.js packages. Powered by [Docker][docker-url].
+Multi test suites runner for Node.js packages. Define your suites including dependant services, Narval will start all using Docker, isolating each suite execution.
 
 [![Build status][travisci-image]][travisci-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![js-standard-style][standard-image]][standard-url]
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Available options are:
 
 option | description | alias 
 --- | --- | ---
+`--logLevel` | Define log level. Available levels are "log", "trace", "debug", "info", "warn" and "error". Default is "info" | `--log`
 `--standard` | Run only Standard linter | `-s`
 `--fix` | Fix Standard errors | `-f`
 `--type <type>` | Run only test suites of provided `<type>` | 
@@ -465,6 +466,9 @@ npm test -- --standard
 
 npm test -- --type=integration
 # Run all test suites of type "integration" defined in the configuration
+
+npm test -- --logLevel=debug
+# Run tests, only print logs with level debug or upper.
 
 npm test -- --type=integration --local
 # Run locally all test suites of type "integration"

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -16,7 +16,6 @@ const baseDockerProcessOptions = function () {
   return {
     cwd: paths.docker(),
     encoding: 'utf8',
-    stdio: [0, 1, 2],
     shell: true,
     windowsHide: true
   }
@@ -126,24 +125,35 @@ const processOptions = function (extraOptions) {
   return (Object.assign({}, baseDockerProcessOptions(), extraOptions))
 }
 
-const runComposeSync = function (command, options) {
-  return new Promise((resolve, reject) => {
-    logs.runningComposeCommand({
-      command: command
+const runComposeSync = function (command, extraOptions) {
+  return options.get()
+    .then(opts => {
+      return new Promise((resolve, reject) => {
+        const stdio = opts.logLevel < 1 ? [0, 1, 2] : [0, 'pipe', 'pipe']
+        logs.runningComposeCommand({
+          command: command
+        })
+        logs.dockerComposeLogs({
+          command: command
+        })
+
+        try {
+          processes.execSync(`docker-compose -f docker-compose.json ${command}`, processOptions({
+            ...extraOptions,
+            stdio
+          }))
+          resolve()
+        } catch (error) {
+          reject(Boom.badImplementation(logs.composeCommandFailed({
+            command: command
+          }, false)))
+        }
+      })
     })
-    try {
-      processes.execSync(`docker-compose -f docker-compose.json ${command}`, processOptions(options))
-      resolve()
-    } catch (error) {
-      reject(Boom.badImplementation(logs.composeCommandFailed({
-        command: command
-      }, false)))
-    }
-  })
 }
 
 module.exports = {
-  run: run,
-  runBefore: runBefore,
-  runComposeSync: runComposeSync
+  run,
+  runBefore,
+  runComposeSync
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -201,6 +201,10 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
     return name
   }
 
+  const describe = () => {
+    return suiteData.describe || ''
+  }
+
   const typeName = function () {
     return suiteTypeName
   }
@@ -452,6 +456,7 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
   return {
     typeName: typeName,
     name: getName,
+    describe: describe,
     hasToRun: hasToRun,
     isDocker: isDocker,
     istanbulArguments: istanbulArgs,

--- a/lib/config.js
+++ b/lib/config.js
@@ -209,11 +209,21 @@ const SuiteResolver = function (suiteData, suiteTypeName, options, suitesByType)
     let baseConfig = {
       dir: `.coverage/${suiteTypeName}/${name}`
     }
-    const config = Object.assign({}, baseConfig, suiteData.coverage && suiteData.coverage.config)
-    return istanbulArguments(config)
+    const userConfig = (suiteData.coverage && suiteData.coverage.config) || {}
+    if (options.logLevel > 3 && !userConfig.print) {
+      userConfig.print = 'none'
+    }
+    return istanbulArguments({
+      ...baseConfig,
+      ...userConfig
+    })
   }
 
   const mochaArgs = function () {
+    suiteData.test.config = suiteData.test.config || {}
+    if (options.logLevel > 3 && !suiteData.test.config.reporter) {
+      suiteData.test.config.reporter = 'mocha-silent-reporter'
+    }
     return mochaArguments(suiteData.test.config, suiteData.test.specs)
   }
 

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -13,6 +13,7 @@ const baseDockerCompose = require('./templates/docker-compose.json')
 const states = require('./states')
 const utils = require('./utils')
 const commands = require('./commands')
+const logs = require('./logs')
 
 const DOCKER_RESOURCES_PATH = 'docker-resources'
 const INSTALL_RESOURCES_PATH = 'install-resources'
@@ -179,6 +180,7 @@ const downVolumes = function () {
   if (!states.get('docker-executed')) {
     return Promise.resolve()
   }
+  logs.dockerVolumesDown()
   return config.allComposeEnvVars()
     .then((vars) => {
       return commands.runComposeSync('down --volumes', {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 const handlebars = require('handlebars')
 
 const tracer = require('./tracer')
+const utils = require('./utils')
 
 handlebars.registerHelper('comma-separated', function (arr) {
   arr = _.isString(arr) ? [arr] : arr
@@ -45,7 +46,7 @@ const LOGS = {
   waitConfig: [' Applying custom config: {{{data.config}}}'],
   errorRunningCommand: ['Error trying to run command. {{{data.message}}}', 'error'],
   errorRunningCommandCode: ['Error running command. Exit code {{data.code}}', 'error'],
-  runningComposeCommand: ['Running Docker command "docker-compose {{{data.command}}}"', 'log'],
+  runningComposeCommand: ['Running Docker command "docker-compose {{{data.command}}}"', 'trace'],
   composeCommandFailed: ['Docker compose command "{{{data.command}}}" failed', 'error'],
   configNotFound: ['Config file {{data.filePath}} not found', 'warn'],
   serviceNotFound: ['The service {{data.name}} was not found', 'warn'],
@@ -58,7 +59,9 @@ const LOGS = {
   standardOk: ['Standard finished OK', 'info'],
   skipStandard: ['Skipping Standard', 'warn'],
   runningSuiteType: ['Running suites of type "{{data.type}}"', 'info'],
-  skipSuiteType: ['Skipping suites of type "{{data.type}}"', 'warn']
+  skipSuiteType: ['Skipping suites of type "{{data.type}}"', 'warn'],
+  serviceLog: [`"{{data.service}}" log =>${utils.NO_COLOR_SEP} {{{data.log}}}`, 'trace'],
+  dockerComposeLogs: [`Docker logs =>`, 'log']
 }
 
 const Log = function (message, level, preData = {}) {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -13,7 +13,7 @@ handlebars.registerHelper('comma-separated', function (arr) {
 
 const SERVICE_LOGS = {
   skip: ['Skipping {{{data.fullName}}}', 'warn'],
-  startRun: ['Running {{{data.fullName}}}', 'info'],
+  startRun: ['Running {{{data.fullName}}}: {{data.describe}}', 'info'],
   finishOk: ['Execution of {{{data.fullName}}} finished OK', 'info'],
   finishError: ['Error running {{{data.fullName}}}', 'error'],
   beforeCommand: ['Executing before command "{{{data.command}}}"', 'debug'],

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -13,7 +13,7 @@ handlebars.registerHelper('comma-separated', function (arr) {
 
 const SERVICE_LOGS = {
   skip: ['Skipping {{{data.fullName}}}', 'warn'],
-  startRun: ['Running {{{data.fullName}}}: {{data.describe}}', 'info'],
+  startRun: [`Running {{{data.fullName}}}:${utils.NO_COLOR_SEP} {{{data.describe}}}`, 'info'],
   finishOk: ['Execution of {{{data.fullName}}} finished OK', 'info'],
   finishError: ['Error running {{{data.fullName}}}', 'error'],
   beforeCommand: ['Executing before command "{{{data.command}}}"', 'debug'],

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -40,10 +40,10 @@ const SERVICE_LOGS = {
 
 const LOGS = {
   skipAllSuites: ['Skipping all test suites', 'warn'],
-  waitingOn: ['Waiting until "{{data.resources}}" is available.{{{data.customConfig}}}', 'debug'],
+  waitingOn: ['Waiting until "{{data.resources}}" is available.', 'debug'],
   waitTimeOut: ['Wait timed out. "{{data.resources}}" is not available.', 'error'],
   waitFinish: ['Wait finished. "{{data.resources}}" is available.', 'debug'],
-  waitConfig: [' Applying custom config: {{{data.config}}}'],
+  waitConfig: [`Waiting config =>${utils.NO_COLOR_SEP} {{{data.config}}}`, 'trace'],
   errorRunningCommand: ['Error trying to run command. {{{data.message}}}', 'error'],
   errorRunningCommandCode: ['Error running command. Exit code {{data.code}}', 'error'],
   runningComposeCommand: ['Running Docker command "docker-compose {{{data.command}}}"', 'trace'],
@@ -61,7 +61,10 @@ const LOGS = {
   runningSuiteType: ['Running suites of type "{{data.type}}"', 'info'],
   skipSuiteType: ['Skipping suites of type "{{data.type}}"', 'warn'],
   serviceLog: [`"{{data.service}}" log =>${utils.NO_COLOR_SEP} {{{data.log}}}`, 'trace'],
-  dockerComposeLogs: [`Docker logs =>`, 'log']
+  dockerComposeLogs: [`Docker logs =>`, 'log'],
+  dockerVolumesDown: ['Unmounting docker-compose volumes', 'debug'],
+  dockerDown: ['Stopping docker-compose', 'debug'],
+  dockerUp: ['Starting docker-compose', 'debug']
 }
 
 const Log = function (message, level, preData = {}) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,11 +1,15 @@
 'use strict'
 
 const commander = require('commander')
+const Boom = require('boom')
 const Promise = require('bluebird')
+const tracer = require('tracer')
 
 const states = require('./states')
 
-const getCommandOptions = function () {
+const LOG_LEVEL = ['log', 'trace', 'debug', 'info', 'warn', 'error']
+
+const getCommandOptions = () => {
   return commander
     .option('-s, --standard', 'Run standard')
     .option('--type <type>', 'Run only all suites of an specific type')
@@ -14,6 +18,7 @@ const getCommandOptions = function () {
     .option('-f, --fix', 'Fix standard')
     .option('-b, --build', 'Build docker images')
     .option('--shell <shell>', 'Custom shell used for running commands without Docker')
+    .option('--log --logLevel <log>', 'Log level')
     .parse(process.argv)
 }
 
@@ -22,6 +27,7 @@ const get = function () {
   if (!options) {
     options = getCommandOptions()
     options.allSuites = false
+    options.logLevel = options.logLevel || 'info'
 
     if (options.fix) {
       options.standard = true
@@ -31,6 +37,10 @@ const get = function () {
       options.standard = true
       options.allSuites = true
     }
+    if (!LOG_LEVEL.includes(options.logLevel)) {
+      return Promise.reject(Boom.badData('Not valid log level'))
+    }
+    tracer.setLevel(options.logLevel)
     states.set('options', options)
   }
   return Promise.resolve(options)

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,7 @@ const tracer = require('tracer')
 
 const states = require('./states')
 
-const LOG_LEVEL = ['log', 'trace', 'debug', 'info', 'warn', 'error']
+const LOG_LEVELS = ['log', 'trace', 'debug', 'info', 'warn', 'error']
 
 const getCommandOptions = () => {
   return commander
@@ -37,7 +37,9 @@ const get = function () {
       options.standard = true
       options.allSuites = true
     }
-    if (!LOG_LEVEL.includes(options.logLevel)) {
+    options.logLevel = LOG_LEVELS.indexOf(options.logLevel)
+
+    if (options.logLevel < 0) {
       return Promise.reject(Boom.badData('Not valid log level'))
     }
     tracer.setLevel(options.logLevel)
@@ -47,5 +49,6 @@ const get = function () {
 }
 
 module.exports = {
-  get: get
+  get,
+  LOG_LEVELS
 }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -97,7 +97,7 @@ const Handler = function (proc, suiteData, options = {}) {
     eventBus.emit('error', err)
   }
 
-  const DataLogger = function (filePath, print, pendingKey) {
+  const DataLogger = function (filePath, pendingKey, print) {
     let blankLine = ''
     let writePending = 0
     let closePending = false
@@ -145,8 +145,11 @@ const Handler = function (proc, suiteData, options = {}) {
       if (data.length) {
         let withoutColors = stripAnsi(data)
         if (print) {
-          console.log(data)
           logged.push(withoutColors)
+          logs.serviceLog({
+            service: suiteData.service,
+            log: data
+          })
         }
         writePending = writePending + 1
         fs.appendFile(fd, stripAnsi(`${blankLine}${withoutColors}`), 'utf8', (error) => {
@@ -194,9 +197,9 @@ const Handler = function (proc, suiteData, options = {}) {
           options.close ? fsExtra.remove(closeFilePath) : Promise.resolve()
         ])
           .then(() => {
-            const out = new DataLogger(outputFilePath, false, 'out', outputFilePath)
-            const err = new DataLogger(errorFilePath, false, 'err', errorFilePath)
-            const outerr = new DataLogger(outerrorFilePath, true, 'outerr', outerrorFilePath)
+            const out = new DataLogger(outputFilePath, 'out', false)
+            const err = new DataLogger(errorFilePath, 'err', false)
+            const outerr = new DataLogger(outerrorFilePath, 'outerr', true)
 
             return Promise.props({
               out: out.open(),
@@ -263,8 +266,8 @@ const Handler = function (proc, suiteData, options = {}) {
 }
 
 module.exports = {
-  fork: fork,
-  spawn: spawn,
-  execSync: execSync,
-  Handler: Handler
+  fork,
+  spawn,
+  execSync,
+  Handler
 }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -140,16 +140,25 @@ const Handler = function (proc, suiteData, options = {}) {
       })
     }
 
+    const printLog = function (data) {
+      _.each(data.split('\n'), logData => {
+        const cleanData = _.trim(logData)
+        if (cleanData.length) {
+          logs.serviceLog({
+            service: suiteData.service,
+            log: logData
+          })
+        }
+      })
+    }
+
     const log = function (data) {
       data = _.trim(data)
       if (data.length) {
         let withoutColors = stripAnsi(data)
         if (print) {
           logged.push(withoutColors)
-          logs.serviceLog({
-            service: suiteData.service,
-            log: data
-          })
+          printLog(data)
         }
         writePending = writePending + 1
         fs.appendFile(fd, stripAnsi(`${blankLine}${withoutColors}`), 'utf8', (error) => {

--- a/lib/suite-docker.js
+++ b/lib/suite-docker.js
@@ -13,6 +13,7 @@ const paths = require('./paths')
 const states = require('./states')
 const commands = require('./commands')
 const processes = require('./processes')
+const logs = require('./logs')
 
 const Runner = function (config, logger) {
   const name = config.name()
@@ -60,6 +61,7 @@ const Runner = function (config, logger) {
       states.set('docker-built', true)
       build = ' --build'
     }
+    logs.dockerUp()
     return runComposeSync(`up --no-start${build}`)
   }
 
@@ -121,6 +123,7 @@ const Runner = function (config, logger) {
   }
 
   const runServicesAndTest = function () {
+    logs.dockerDown()
     return runComposeSync('down').then(() => {
       return runDockerUp().then(() => {
         return Promise.map(config.services(), runService).then(startedServices => {

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -29,7 +29,9 @@ const Suite = function (suiteData, suiteTypeName, options, suitesByType) {
   const run = function () {
     let runner
     if (configResolver.hasToRun()) {
-      logger.startRun()
+      logger.startRun({
+        describe: configResolver.describe()
+      })
       runner = configResolver.isDocker() ? runDocker : runLocal
 
       return runner().then(() => {

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -2,8 +2,28 @@
 
 const _ = require('lodash')
 const tracer = require('tracer')
+const colors = require('colors')
+
+const utils = require('./utils')
+
+const Filter = (color) => {
+  return (str) => {
+    const splittedStr = str.split(utils.NO_COLOR_SEP)
+    const colorLog = splittedStr[0]
+    const noColorLog = splittedStr[1] || ''
+    return `${color(colorLog)}${noColorLog}`
+  }
+}
 
 const logger = tracer.colorConsole({
+  filters: {
+    trace: Filter(colors.magenta),
+    debug: Filter(colors.cyan),
+    info: Filter(colors.green),
+    warn: Filter(colors.yellow),
+    error: Filter(colors.red.bold),
+    fatal: Filter(colors.red.bold)
+  },
   format: [
     '{{timestamp}} [Narval] [{{title}}] {{message}}',
     {

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 const tracer = require('tracer')
-const colors = require('colors')
+const colors = require('colors/safe')
 
 const utils = require('./utils')
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash')
 
+const NO_COLOR_SEP = '<narval-no-tracer-color>'
+
 const ObjectToArguments = function (defaultConfig, eq, singleDashParams) {
   singleDashParams = singleDashParams || []
   eq = eq || ' '
@@ -53,8 +55,9 @@ const extendProcessEnvVars = function (vars) {
 }
 
 module.exports = {
-  ObjectToArguments: ObjectToArguments,
-  commandArguments: commandArguments,
-  serviceNameToVarName: serviceNameToVarName,
-  extendProcessEnvVars: extendProcessEnvVars
+  ObjectToArguments,
+  commandArguments,
+  serviceNameToVarName,
+  extendProcessEnvVars,
+  NO_COLOR_SEP
 }

--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -22,19 +22,16 @@ const wait = function (config) {
     interval: 100,
     timeout: 60000
   }
-  let customConfigLog = ''
   if (!config) {
     return Promise.resolve()
   }
 
-  customConfigLog = logs.waitConfig({
-    config: JSON.stringify(config)
-  }, false)
-
   return new Promise((resolve, reject) => {
     logs.waitingOn({
-      resources: config.resources,
-      customConfig: customConfigLog
+      resources: config.resources
+    })
+    logs.waitConfig({
+      config: JSON.stringify(config)
     })
     libs.waitOn(Object.assign({}, waitOnDefaultOptions, config), (error) => {
       if (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narval",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Multi test suites runner for Node.js packages. Docker based",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
   "dependencies": {
     "bluebird": "3.5.1",
     "boom": "7.2.0",
+    "colors": "1.3.1",
     "commander": "2.17.1",
     "fs-extra": "7.0.0",
     "handlebars": "4.0.11",
     "js-yaml": "3.12.0",
     "lodash": "4.17.10",
+    "mocha-silent-reporter": "1.0.0",
     "mocha-sinon-chai": "3.0.0",
     "standard": "11.0.1",
     "strip-ansi": "4.0.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=narval
-sonar.projectVersion=2.0.0
+sonar.projectVersion=2.1.0
 
 sonar.sources=.
 sonar.exclusions=node_modules/**,test/integration/packages/**

--- a/test/integration/configs/api-no-mongo.yml
+++ b/test/integration/configs/api-no-mongo.yml
@@ -40,6 +40,7 @@ suites:
           x: "**/_node_modules/**"
   end-to-end:
     - name: books-api
+      describe: Books api should work without database
       before:
         docker:
           down-volumes: true

--- a/test/integration/configs/api.yml
+++ b/test/integration/configs/api.yml
@@ -32,6 +32,7 @@ docker-containers:
 suites:
   unit: 
     - name: unit
+      describe: Unitary tests
       test:
         specs: test/unit
       coverage:
@@ -40,6 +41,7 @@ suites:
           x: "**/_node_modules/**"
   end-to-end:
     - name: books-api
+      describe: Books api should work and save data to database
       before:
         docker:
           down-volumes: true

--- a/test/integration/configs/example.yml
+++ b/test/integration/configs/example.yml
@@ -30,6 +30,7 @@ docker-containers:
 suites:
   unit: 
     - name: unit
+      describe: Unitary tests
       test:
         specs: test/unit
       coverage:
@@ -37,6 +38,7 @@ suites:
           dir: .coverage/unit
   end-to-end:
     - name: books-api
+      describe: Books api should work and save data to mongodb.
       before:
         docker:
           down-volumes: true
@@ -70,6 +72,7 @@ suites:
         from: api-server
   integration:
     - name: logs
+      describe: Books api logs should work and print logs when an api request is received.
       services:
         - name: mongodb
           docker:
@@ -111,6 +114,7 @@ suites:
       coverage:
         enabled: false
     - name: commands
+      describe: Books api command should work and write all books to a file in json format.
       services:
         - name: mongodb
           docker:

--- a/test/integration/specs/descriptions/api-no-mongo.specs.js
+++ b/test/integration/specs/descriptions/api-no-mongo.specs.js
@@ -1,0 +1,23 @@
+
+const test = require('../../../../index')
+const utils = require('../utils')
+
+test.describe('descriptions', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  test.it('should have not printed unit tests description', () => {
+    return test.expect(outerrLog).to.include(`Running "unit" suite "unit": \n`)
+  })
+
+  test.it('should have printed the books-api suite description', () => {
+    return test.expect(outerrLog).to.include(`Running "end-to-end" suite "books-api": Books api should work without database`)
+  })
+})

--- a/test/integration/specs/descriptions/api-no-mongo.specs.js
+++ b/test/integration/specs/descriptions/api-no-mongo.specs.js
@@ -14,7 +14,7 @@ test.describe('descriptions', () => {
   })
 
   test.it('should have not printed unit tests description', () => {
-    return test.expect(outerrLog).to.include(`Running "unit" suite "unit": \n`)
+    return test.expect(outerrLog).to.include(`Running "unit" suite "unit":\n`)
   })
 
   test.it('should have printed the books-api suite description', () => {

--- a/test/integration/specs/descriptions/api.specs.js
+++ b/test/integration/specs/descriptions/api.specs.js
@@ -1,0 +1,23 @@
+
+const test = require('../../../../index')
+const utils = require('../utils')
+
+test.describe('descriptions', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  test.it('should have printed the unit tests description', () => {
+    return test.expect(outerrLog).to.include(`Running "unit" suite "unit": Unitary tests`)
+  })
+
+  test.it('should have printed the books-api suite description', () => {
+    return test.expect(outerrLog).to.include(`Running "end-to-end" suite "books-api": Books api should work and save data to database`)
+  })
+})

--- a/test/integration/specs/log-levels/api-debug.specs.js
+++ b/test/integration/specs/log-levels/api-debug.specs.js
@@ -1,0 +1,44 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expects = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.include(expect)
+        })
+      })
+    })
+  }
+
+  const expectsNot = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have not logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.not.include(expect)
+        })
+      })
+    })
+  }
+
+  expectsNot(definitions.log)
+  expectsNot(definitions.trace)
+  expects(definitions.debug)
+  expects(definitions.info)
+  expects(definitions.warn)
+})

--- a/test/integration/specs/log-levels/api-error.specs.js
+++ b/test/integration/specs/log-levels/api-error.specs.js
@@ -1,0 +1,38 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expectsNot = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have not logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.not.include(expect)
+        })
+      })
+    })
+  }
+
+  expectsNot(definitions.log)
+  expectsNot(definitions.trace)
+  expectsNot(definitions.debug)
+  expectsNot(definitions.info)
+  expectsNot(definitions.warn)
+
+  test.it('should have logged only errors', () => {
+    test.expect(outerrLog).to.not.include('[Narval]')
+  })
+})

--- a/test/integration/specs/log-levels/api-info.specs.js
+++ b/test/integration/specs/log-levels/api-info.specs.js
@@ -1,0 +1,44 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expects = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.include(expect)
+        })
+      })
+    })
+  }
+
+  const expectsNot = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have not logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.not.include(expect)
+        })
+      })
+    })
+  }
+
+  expectsNot(definitions.log)
+  expectsNot(definitions.trace)
+  expectsNot(definitions.debug)
+  expects(definitions.info)
+  expects(definitions.warn)
+})

--- a/test/integration/specs/log-levels/api-log.specs.js
+++ b/test/integration/specs/log-levels/api-log.specs.js
@@ -18,10 +18,8 @@ test.describe('services logs', () => {
 
   const expects = (logDefinitions, log) => {
     _.each(logDefinitions, (definition) => {
-      console.log(definition)
       test.it(`should have logged ${definition.it}`, () => {
         _.each(definition.expects, (expect) => {
-          console.log(expect)
           test.expect(outerrLog).to.include(expect)
         })
       })

--- a/test/integration/specs/log-levels/api-log.specs.js
+++ b/test/integration/specs/log-levels/api-log.specs.js
@@ -1,0 +1,36 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expects = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      console.log(definition)
+      test.it(`should have logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          console.log(expect)
+          test.expect(outerrLog).to.include(expect)
+        })
+      })
+    })
+  }
+
+  expects(definitions.log)
+  expects(definitions.trace)
+  expects(definitions.debug)
+  expects(definitions.info)
+  expects(definitions.warn)
+})

--- a/test/integration/specs/log-levels/api-trace.specs.js
+++ b/test/integration/specs/log-levels/api-trace.specs.js
@@ -1,0 +1,44 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expects = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.include(expect)
+        })
+      })
+    })
+  }
+
+  const expectsNot = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have not logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.not.include(expect)
+        })
+      })
+    })
+  }
+
+  expectsNot(definitions.log)
+  expects(definitions.trace)
+  expects(definitions.debug)
+  expects(definitions.info)
+  expects(definitions.warn)
+})

--- a/test/integration/specs/log-levels/api-warn.specs.js
+++ b/test/integration/specs/log-levels/api-warn.specs.js
@@ -1,0 +1,44 @@
+const _ = require('lodash')
+
+const test = require('../../../../index')
+
+const utils = require('../utils')
+const definitions = require('./logs-definitions')
+
+test.describe('services logs', () => {
+  let outerrLog
+
+  test.before((done) => {
+    utils.readOutErr()
+      .then((log) => {
+        outerrLog = log
+        done()
+      })
+  })
+
+  const expects = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.include(expect)
+        })
+      })
+    })
+  }
+
+  const expectsNot = (logDefinitions, log) => {
+    _.each(logDefinitions, (definition) => {
+      test.it(`should have not logged ${definition.it}`, () => {
+        _.each(definition.expects, (expect) => {
+          test.expect(outerrLog).to.not.include(expect)
+        })
+      })
+    })
+  }
+
+  expectsNot(definitions.log)
+  expectsNot(definitions.trace)
+  expectsNot(definitions.debug)
+  expectsNot(definitions.info)
+  expects(definitions.warn)
+})

--- a/test/integration/specs/log-levels/logs-definitions.js
+++ b/test/integration/specs/log-levels/logs-definitions.js
@@ -1,0 +1,118 @@
+module.exports = {
+  log: [
+    {
+      it: 'docker logs',
+      expects: [
+        '[Narval] [LOG] Docker logs =>',
+        'Removing network docker_default'
+      ]
+    },
+    {
+      it: 'docker logs',
+      expects: [
+        'Creating network "docker_default" with the default driver'
+      ]
+    }
+  ],
+  trace: [
+    {
+      it: 'docker compose unmounting volumes command',
+      expects: [
+        '[TRACE] Running Docker command "docker-compose down --volumes'
+      ]
+    },
+    {
+      it: 'docker compose start command',
+      expects: [
+        '[TRACE] Running Docker command "docker-compose up --no-start'
+      ]
+    },
+    {
+      it: 'services start docker commands',
+      expects: [
+        '[Narval] [TRACE] Running Docker command "docker-compose start mongodb-container"',
+        '[Narval] [TRACE] Running Docker command "docker-compose start api-container"'
+      ]
+    },
+    {
+      it: 'mongodb services logs',
+      expects: [
+        'I CONTROL  [initandlisten] MongoDB starting',
+        'WAITING FOR: tcp:mongodb-container:27017',
+        '[Narval] [DEBUG] RUNNING COMMAND: test/commands/start-server.sh',
+        'Connecting to database mongodb://mongodb-container/narval-api-test',
+        'WAITING FOR: tcp:api-container:4000',
+        '{"title":"The Sun Also Rises","author":"Ernest Hemingway"}',
+        'Retrieving all books from database'
+      ]
+    }
+  ],
+  debug: [
+    {
+      it: 'unit tests execution start',
+      expects: [
+        '[Narval] [DEBUG] Starting tests of "unit" suite "unit" with coverage enabled'
+      ]
+    },
+    {
+      it: 'docker compose unmounting volumes',
+      expects: [
+        '[Narval] [DEBUG] Unmounting docker-compose volumes'
+      ]
+    },
+    {
+      it: 'docker compose start',
+      expects: [
+        '[Narval] [DEBUG] Starting docker-compose'
+      ]
+    },
+    {
+      it: 'services start',
+      expects: [
+        '[DEBUG] Starting docker service "mongodb" of suite "books-api"',
+        '[DEBUG] Starting docker service "api-server" of suite "books-api"'
+      ]
+    },
+    {
+      it: 'the wait for logs',
+      expects: [
+        '[Narval] [DEBUG] Services "mongodb, api-server" are still running. Waiting...'
+      ]
+    }
+  ],
+  info: [
+    {
+      it: 'standard execution start',
+      expects: [
+        '[Narval] [INFO] Running Standard'
+      ]
+    },
+    {
+      it: 'unit tests execution',
+      expects: [
+        'should start the server'
+      ]
+    },
+    {
+      it: 'coverage summary',
+      expects: [
+        '== Coverage summary =='
+      ]
+    },
+    {
+      it: 'the end of tests suites executions',
+      expects: [
+        '[Narval] [INFO] Execution of "end-to-end" suite "books-api" finished OK'
+      ]
+    }
+  ],
+  warn: [
+    {
+      it: 'services exit warnings',
+      expects: [
+        '[WARN] Docker container "api-container" of service "api-server" exited with code "137"',
+        '[WARN] Docker container "mongodb-container" of service "mongodb" exited with code "137"'
+      ]
+    }
+  ]
+}

--- a/test/unit/lib/commands.specs.js
+++ b/test/unit/lib/commands.specs.js
@@ -307,6 +307,28 @@ test.describe('commands', () => {
         })
     })
 
+    test.it('should configure the stdio to print logs if options log level is lower than trace', () => {
+      mocksSandbox.options.stubs.get.resolves({
+        logLevel: 0
+      })
+      return commands.runComposeSync(fooCommand)
+        .then(() => {
+          const execSyncArguments = mocksSandbox.processes.stubs.execSync.getCall(0).args
+          return test.expect(execSyncArguments[1].stdio).to.deep.equal([0, 1, 2])
+        })
+    })
+
+    test.it('should configure the stdio to not print logs if options log level is upper than trace', () => {
+      mocksSandbox.options.stubs.get.resolves({
+        logLevel: 1
+      })
+      return commands.runComposeSync(fooCommand)
+        .then(() => {
+          const execSyncArguments = mocksSandbox.processes.stubs.execSync.getCall(0).args
+          return test.expect(execSyncArguments[1].stdio).to.deep.equal([0, 'pipe', 'pipe'])
+        })
+    })
+
     test.it('should extend the base docker options with the received options', () => {
       const fooOptionVal = 'foo value'
       const fooDockerPath = 'foo docker path'

--- a/test/unit/lib/config.fixtures.js
+++ b/test/unit/lib/config.fixtures.js
@@ -130,6 +130,7 @@ const localSuiteWithNoService = {
 
 const dockerSuite = {
   name: 'fooDockerSuite',
+  describe: 'Foo description',
   coverage: {
     from: 'fooService1'
   },

--- a/test/unit/lib/config.mocks.js
+++ b/test/unit/lib/config.mocks.js
@@ -20,6 +20,7 @@ const Mock = function () {
   const suiteResolverStubs = {
     typeName: sandbox.stub(),
     name: sandbox.stub(),
+    describe: sandbox.stub(),
     hasToRun: sandbox.stub(),
     isDocker: sandbox.stub(),
     istanbulArguments: sandbox.stub().returns(''),

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -378,6 +378,35 @@ test.describe('config', () => {
         initResolver()
         test.expect(suiteResolver.istanbulArguments()).to.equal('--include-all-sources --root=. --colors --print=detail --dir=.coverage/custom --verbose --report=text')
       })
+
+      test.it('should add a print=none option to istanbul arguments if logLevel is upper to info', () => {
+        baseData.coverage = {
+          config: {
+            dir: '.coverage/custom',
+            verbose: true,
+            report: 'text'
+          }
+        }
+        initResolver({
+          logLevel: 4
+        })
+        test.expect(suiteResolver.istanbulArguments()).to.equal('--include-all-sources --root=. --colors --print=none --dir=.coverage/custom --verbose --report=text')
+      })
+
+      test.it('should not add a print=none option to istanbul arguments if config has defined an explicit print', () => {
+        baseData.coverage = {
+          config: {
+            dir: '.coverage/custom',
+            verbose: true,
+            print: 'detail',
+            report: 'text'
+          }
+        }
+        initResolver({
+          logLevel: 4
+        })
+        test.expect(suiteResolver.istanbulArguments()).to.equal('--include-all-sources --root=. --colors --print=detail --dir=.coverage/custom --verbose --report=text')
+      })
     })
 
     test.describe('mochaArguments method', () => {
@@ -389,6 +418,31 @@ test.describe('config', () => {
           grep: 'grepped'
         }
         initResolver()
+        test.expect(suiteResolver.mochaArguments()).to.equal('--colors --reporter list --grep grepped foo/path/specs')
+      })
+
+      test.it('should add a silent reporter to mocha arguments if logLevel is upper to info', () => {
+        baseData = fixtures.config.localSuite
+        baseData.test.config = {
+          recursive: false,
+          grep: 'grepped'
+        }
+        initResolver({
+          logLevel: 4
+        })
+        test.expect(suiteResolver.mochaArguments()).to.equal('--colors --reporter mocha-silent-reporter --grep grepped foo/path/specs')
+      })
+
+      test.it('should not add a silent reporter to mocha arguments if config has defined an explicit reporter', () => {
+        baseData = fixtures.config.localSuite
+        baseData.test.config = {
+          recursive: false,
+          reporter: 'list',
+          grep: 'grepped'
+        }
+        initResolver({
+          logLevel: 4
+        })
         test.expect(suiteResolver.mochaArguments()).to.equal('--colors --reporter list --grep grepped foo/path/specs')
       })
     })

--- a/test/unit/lib/config.specs.js
+++ b/test/unit/lib/config.specs.js
@@ -327,6 +327,18 @@ test.describe('config', () => {
       })
     })
 
+    test.describe('describe method', () => {
+      test.it('should return the description of the suite', () => {
+        test.expect(suiteResolver.describe()).to.equal('Foo description')
+      })
+
+      test.it('should return an empty string if the suite has no describe field', () => {
+        delete baseData.describe
+        initResolver()
+        test.expect(suiteResolver.describe()).to.equal('')
+      })
+    })
+
     test.describe('hasToRun method', () => {
       test.it('should return true if no suite option is received', () => {
         test.expect(suiteResolver.hasToRun()).to.equal(true)

--- a/test/unit/lib/docker.specs.js
+++ b/test/unit/lib/docker.specs.js
@@ -18,6 +18,7 @@ test.describe('docker', () => {
     mocksSandbox = new mocks.Sandbox([
       'paths',
       'config',
+      'logs',
       'utils',
       'commands'
     ])

--- a/test/unit/lib/options.specs.js
+++ b/test/unit/lib/options.specs.js
@@ -84,7 +84,7 @@ test.describe('options', () => {
     test.it('should set default log level as "info" if it is not specified', () => {
       return options.get()
         .then((opts) => {
-          return test.expect(opts.logLevel).to.equal('info')
+          return test.expect(opts.logLevel).to.equal(3)
         })
     })
 

--- a/test/unit/lib/options.specs.js
+++ b/test/unit/lib/options.specs.js
@@ -1,6 +1,8 @@
 
 const commander = require('commander')
 const Promise = require('bluebird')
+const tracer = require('tracer')
+const Boom = require('boom')
 
 const test = require('../../../index')
 
@@ -40,6 +42,7 @@ test.describe('options', () => {
     test.beforeEach(() => {
       commanderMock = new CommanderMock()
       sandbox = test.sinon.createSandbox()
+      sandbox.stub(tracer, 'setLevel')
       sandbox.stub(commander, 'option').callsFake(commanderMock.option)
       sandbox.stub(states, 'get').returns(undefined)
       sandbox.stub(states, 'set')
@@ -53,11 +56,11 @@ test.describe('options', () => {
       return test.expect(options.get()).to.be.an.instanceof(Promise)
     })
 
-    test.it('should get the seven available options from command line arguments', () => {
+    test.it('should get the eight available options from command line arguments', () => {
       return options.get()
         .then(() => {
           return Promise.all([
-            test.expect(commanderMock.option.callCount).to.equal(7),
+            test.expect(commanderMock.option.callCount).to.equal(8),
             test.expect(commanderMock.parse.callCount).to.equal(1),
             test.expect(commanderMock.parse).to.have.been.calledWith(process.argv)
           ])
@@ -68,6 +71,32 @@ test.describe('options', () => {
       return options.get()
         .then(() => {
           return test.expect(states.set).to.have.been.called()
+        })
+    })
+
+    test.it('should call to tracer setLevel method to set the current log level', () => {
+      return options.get()
+        .then(() => {
+          return test.expect(tracer.setLevel).to.have.been.called()
+        })
+    })
+
+    test.it('should set default log level as "info" if it is not specified', () => {
+      return options.get()
+        .then((opts) => {
+          return test.expect(opts.logLevel).to.equal('info')
+        })
+    })
+
+    test.it('should reject the promise if log level option is not valid', () => {
+      commanderMock.returns({
+        logLevel: 'foo'
+      })
+      return options.get()
+        .then((opts) => {
+          return test.assert.fail()
+        }, (err) => {
+          return test.expect(Boom.isBoom(err)).to.be.true()
         })
     })
 

--- a/test/unit/lib/processes.specs.js
+++ b/test/unit/lib/processes.specs.js
@@ -186,7 +186,10 @@ test.describe('processes', () => {
       childProcessMock.stubs.spawn.stdout.on.returns(`  ${fooData}`)
       handler = new processes.Handler(fooProcess, fooSuiteData)
       handler.on('close', () => {
-        test.expect(console.log).to.have.been.calledWith(fooData)
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo data',
+          service: 'fooService'
+        })
         test.expect(mocksSandbox.fs.stubs.appendFile.getCall(0).args[1]).to.contain(fooData)
         done()
       })
@@ -208,7 +211,10 @@ test.describe('processes', () => {
       handler.on('close', (data) => {
         test.expect(data.lastLog).to.equal(fooData)
         test.expect(data.processCode).to.equal(0)
-        test.expect(console.log).to.have.been.calledWith(fooData)
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo data',
+          service: 'fooService'
+        })
         test.expect(fsExtra.remove).to.have.been.calledWith(fooCloseFile)
         test.expect(mocksSandbox.fs.stubs.writeFileSync.getCall(0).args[1]).to.equal(0)
         done()
@@ -227,8 +233,14 @@ test.describe('processes', () => {
       handler.on('close', (data) => {
         test.expect(data.lastLog).to.equal(fooError)
         test.expect(data.processCode).to.equal(0)
-        test.expect(console.log).to.have.been.calledWith(fooData)
-        test.expect(console.log).to.have.been.calledWith(fooError)
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo data',
+          service: 'fooService'
+        })
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: fooError,
+          service: 'fooService'
+        })
         test.expect(fsExtra.remove).to.have.been.calledWith(fooCloseFile)
         test.expect(mocksSandbox.fs.stubs.writeFileSync.getCall(0).args[1]).to.equal(0)
         done()
@@ -241,7 +253,10 @@ test.describe('processes', () => {
       childProcessMock.stubs.spawn.stderr.on.runOnRegister(true)
       handler = new processes.Handler(fooProcess, fooSuiteData)
       handler.on('close', () => {
-        test.expect(console.log).to.have.been.calledWith(fooErrorData)
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: fooErrorData,
+          service: 'fooService'
+        })
         test.expect(mocksSandbox.fs.stubs.appendFile.getCall(0).args[1]).to.contain(fooErrorData)
         done()
       })

--- a/test/unit/lib/processes.specs.js
+++ b/test/unit/lib/processes.specs.js
@@ -195,6 +195,26 @@ test.describe('processes', () => {
       })
     })
 
+    test.it('should not write process output log lines that are empty', (done) => {
+      childProcessMock.stubs.spawn.stdout.on.returns(' foo \n     \nfoo2')
+      handler = new processes.Handler(fooProcess, fooSuiteData)
+      handler.on('close', () => {
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo ',
+          service: 'fooService'
+        })
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo2',
+          service: 'fooService'
+        })
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.not.have.been.calledWith({
+          log: '',
+          service: 'fooService'
+        })
+        done()
+      })
+    })
+
     test.it('should write a file with the end code if the option close is received', function (done) {
       this.timeout(5000)
       childProcessMock.stubs.spawn.on.runOnRegister(false)

--- a/test/unit/lib/utils.specs.js
+++ b/test/unit/lib/utils.specs.js
@@ -47,6 +47,10 @@ test.describe('utils', () => {
       objectToArgs = new utils.ObjectToArguments()
     })
 
+    test.it('should return an empty string if no object is provided', () => {
+      test.expect(objectToArgs()).to.equal('')
+    })
+
     test.it('given an object, should return an string with the equivalent converted to command line arguments', () => {
       test.expect(objectToArgs({
         fooVar1: 'fooVal1',


### PR DESCRIPTION
* Add a new command line option called "loglevel" that will define logs that are printed to console, or silenced. This new option should have no effect to services log files, which will continue saving all.
* Add a "describe" field to suites that is logged when suites starts.

closes #20 , closes #23 