### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- Allow arrays in test and coverage configurations. Arrays are converted into same argument repeated with different values as many times as elements has the array.
 ### Changed
 ### Fixed
+- Print logs of tests executed inside docker with log level info
 ### Removed
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
-- Allow arrays in test and coverage configurations. Arrays are converted into same argument repeated with different values as many times as elements has the array.
 ### Changed
 ### Fixed
-- Print logs of tests executed inside docker with log level info
 ### Removed
 ### BREAKING CHANGES
+
+## [2.2.1] - 2018-08-18
+### Added
+- Allow arrays in test and coverage configurations. Arrays are converted into same argument repeated with different values as many times as elements has the array.
+
+### Fixed
+- Print logs of tests executed inside docker with log level info.
 
 ## [2.2.0] - 2018-08-18
 ### Added

--- a/lib/docker-resources/.narval/scripts/run-cmd.sh
+++ b/lib/docker-resources/.narval/scripts/run-cmd.sh
@@ -7,8 +7,8 @@ coverage_enabled=$4
 wait_on=$5
 exit_after=$6
 
-log_title="[Narval] [DEBUG]"
-log_sep="================================"
+log_title="[Narval] [TRACE]"
+log_sep="[Narval] [TRACE]================================"
 
 # echo "$log_sep"
 # echo "$log_title RUN COMMAND OPTIONS:"
@@ -21,10 +21,10 @@ log_sep="================================"
 
 if [ -z "$command_to_run" ]; then
   if [ "$exit_after" == "" ]; then
-    echo "There is no command defined to be run. Container will wait until killed"
+    echo "${log_title}There is no command defined to be run. Container will wait until killed"
     ./.narval/scripts/empty-interval.js
   else
-    echo "There is no command defined to be run. Exiting..."
+    echo "${log_title}There is no command defined to be run. Exiting..."
   fi
 else
   if [ "$command_to_run" == "narval-default-test-command" ]; then
@@ -44,12 +44,12 @@ else
   fi
 
   if [ "$wait_on" != "" ]; then
-    echo "WAITING FOR: $wait_on"
+    echo "${log_title}WAITING FOR: $wait_on"
     wait-on $wait_on
   fi
       
   echo "$log_sep"
-  echo "$log_title RUNNING COMMAND: $command_to_run"
+  echo "${log_title}RUNNING COMMAND: $command_to_run"
 
   ./$command_to_run
 fi

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -41,6 +41,9 @@ const execSync = function (command, options) {
 }
 
 const Handler = function (proc, suiteData, options = {}) {
+  const dockerTraceToRemove = /\[Narval\] \[TRACE\]/
+  const testLogMatcher = /test-container_1[\s]*\|/
+  const containerLogMatcher = /[\S]*-container_[\d]*[\s]*\|/
   const eventBus = new events.EventEmitter()
   let filesReady = false
   let isClosed = false
@@ -140,14 +143,24 @@ const Handler = function (proc, suiteData, options = {}) {
       })
     }
 
+    const printTracer = (log) => {
+      logs.serviceLog({
+        service: suiteData.service,
+        log
+      })
+    }
+
     const printLog = function (data) {
       _.each(data.split('\n'), logData => {
         const cleanData = _.trim(logData)
         if (cleanData.length) {
-          logs.serviceLog({
-            service: suiteData.service,
-            log: logData
-          })
+          if (dockerTraceToRemove.test(cleanData)) {
+            printTracer(cleanData.replace(dockerTraceToRemove, '').replace(containerLogMatcher, ''))
+          } else if (testLogMatcher.test(cleanData)) {
+            console.log(cleanData.replace(testLogMatcher, ''))
+          } else {
+            printTracer(cleanData.replace(containerLogMatcher, ''))
+          }
         }
       })
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,10 @@ const ObjectToArguments = function (defaultConfig, eq, singleDashParams) {
         if (value) {
           baseParams.push(sep + key)
         }
+      } else if (_.isArray(value)) {
+        _.each(value, (val) => {
+          baseParams.push(sep + key + eq + val)
+        })
       } else {
         baseParams.push(sep + key + eq + value)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narval",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Multi test suites runner for Node.js packages. Docker based",
   "main": "index.js",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=narval
-sonar.projectVersion=2.2.0
+sonar.projectVersion=2.2.1
 
 sonar.sources=.
 sonar.exclusions=node_modules/**,test/integration/packages/**

--- a/test/integration/specs/api-coverage/docker.mongodb-ko.specs.js
+++ b/test/integration/specs/api-coverage/docker.mongodb-ko.specs.js
@@ -20,7 +20,7 @@ test.describe('api-docker-coverage suite execution mongodb failing', () => {
   test.it('should have exited started api service and exited with an error, after timeout waiting for mongodb', () => {
     return Promise.all([
       test.expect(outerrLog).to.include('Error: Timeout'),
-      test.expect(outerrLog).to.include('[Narval] [DEBUG] RUNNING COMMAND: node_modules/.bin/narval-msc-istanbul'),
+      test.expect(outerrLog).to.include('RUNNING COMMAND: node_modules/.bin/narval-msc-istanbul'),
       test.expect(outerrLog).to.include('[Narval] [ERROR] Docker container "api-container" of service "api-server" exited with code "1"')
     ])
   })

--- a/test/integration/specs/log-levels/logs-definitions.js
+++ b/test/integration/specs/log-levels/logs-definitions.js
@@ -39,7 +39,7 @@ module.exports = {
       expects: [
         'I CONTROL  [initandlisten] MongoDB starting',
         'WAITING FOR: tcp:mongodb-container:27017',
-        '[Narval] [DEBUG] RUNNING COMMAND: test/commands/start-server.sh',
+        'RUNNING COMMAND: test/commands/start-server.sh',
         'Connecting to database mongodb://mongodb-container/narval-api-test',
         'WAITING FOR: tcp:api-container:4000',
         '{"title":"The Sun Also Rises","author":"Ernest Hemingway"}',

--- a/test/unit/lib/processes.specs.js
+++ b/test/unit/lib/processes.specs.js
@@ -200,7 +200,7 @@ test.describe('processes', () => {
       handler = new processes.Handler(fooProcess, fooSuiteData)
       handler.on('close', () => {
         test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
-          log: 'foo ',
+          log: 'foo',
           service: 'fooService'
         })
         test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
@@ -209,6 +209,32 @@ test.describe('processes', () => {
         })
         test.expect(mocksSandbox.logs.stubs.serviceLog).to.not.have.been.calledWith({
           log: '',
+          service: 'fooService'
+        })
+        done()
+      })
+    })
+
+    test.it('should console processes logs that belongs to test services', (done) => {
+      childProcessMock.stubs.spawn.stdout.on.returns('test-container_1     | foo \ntest-container_1     | foo 2 ')
+      handler = new processes.Handler(fooProcess, fooSuiteData)
+      handler.on('close', () => {
+        test.expect(console.log).to.have.been.calledWith(' foo')
+        test.expect(console.log).to.have.been.calledWith(' foo 2')
+        done()
+      })
+    })
+
+    test.it('should trace processes logs that belongs to test services, but have a [trace] identifier', (done) => {
+      childProcessMock.stubs.spawn.stdout.on.returns('test-container_1     |[Narval] [TRACE]foo \ntest-container_1     |[Narval] [TRACE] foo 2 ')
+      handler = new processes.Handler(fooProcess, fooSuiteData)
+      handler.on('close', () => {
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: 'foo',
+          service: 'fooService'
+        })
+        test.expect(mocksSandbox.logs.stubs.serviceLog).to.have.been.calledWith({
+          log: ' foo 2',
           service: 'fooService'
         })
         done()

--- a/test/unit/lib/utils.specs.js
+++ b/test/unit/lib/utils.specs.js
@@ -66,6 +66,19 @@ test.describe('utils', () => {
       })).to.equal('--fooVar1 fooVal1 --fooVar2 --fooVar3 testing')
     })
 
+    test.it('should convert array values, and add one argument for each element of the array', () => {
+      objectToArgs = new utils.ObjectToArguments({}, '=', ['x'])
+      test.expect(objectToArgs({
+        fooVar1: 'fooVal1',
+        fooVar2: true,
+        x: [
+          'testing',
+          'testing2',
+          'testing3'
+        ]
+      })).to.equal('--fooVar1=fooVal1 --fooVar2 -x=testing -x=testing2 -x=testing3')
+    })
+
     test.it('should use the defined equal to separate vars and values', () => {
       objectToArgs = new utils.ObjectToArguments({}, '=>')
       test.expect(objectToArgs({


### PR DESCRIPTION
- Allow arrays in test and coverage configurations. Arrays are converted into same argument repeated with different values as many times as elements has the array.
- Print logs of tests executed inside docker with log level info.

closes #52 , closes #60 
